### PR TITLE
improve cli reconnection ux and fix reconnect bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ justtunnel 3000 --log-level debug        # verbose logging
 |------|-------|---------|-------------|
 | `--subdomain` | `-s` | — | Request a specific reserved subdomain |
 | `--log-level` | — | `info` | `debug`, `info`, `warn`, `error` |
+| `--max-reconnect-attempts` | — | `50` | Max reconnection attempts before giving up (0 = unlimited) |
 | `--config` | — | `~/.config/justtunnel/config.yaml` | Config file path |
 
 ### `justtunnel auth <key>`
@@ -122,6 +123,7 @@ Config file: `~/.config/justtunnel/config.yaml`
 auth_token: "justtunnel_sk_live_abc123..."
 server_url: "wss://api.justtunnel.dev/ws"
 log_level: "info"
+max_reconnect_attempts: 50
 ```
 
 All fields can be overridden with environment variables (prefix `JUSTTUNNEL_`):
@@ -131,6 +133,7 @@ All fields can be overridden with environment variables (prefix `JUSTTUNNEL_`):
 | `JUSTTUNNEL_AUTH_TOKEN` | `auth_token` | — |
 | `JUSTTUNNEL_SERVER_URL` | `server_url` | `wss://api.justtunnel.dev/ws` |
 | `JUSTTUNNEL_LOG_LEVEL` | `log_level` | `info` |
+| `JUSTTUNNEL_MAX_RECONNECT_ATTEMPTS` | `max_reconnect_attempts` | `50` |
 
 ## Terminal Output
 
@@ -139,6 +142,15 @@ The CLI uses colored output, animated spinners, and an ASCII banner when running
 **Color-coded request logs:** 2xx responses are green, 3xx/4xx are yellow, 5xx are red.
 
 **Spinners** show progress during connection, reconnection (with countdown), and device auth flows. In non-TTY environments (e.g., piped output, CI), spinners are replaced with a single static line.
+
+**Reconnection behavior:** When the WebSocket connection drops, the CLI:
+
+1. Prints a timestamped "Disconnected" message
+2. Retries with exponential backoff (1s, 2s, 4s, ... up to 30s cap), showing a countdown spinner
+3. After reconnecting, prints a status block with the tunnel URL, forwarding target, and total downtime
+4. Warns if the subdomain changed (free-tier tunnels may get a new random subdomain)
+5. Gives up after 50 attempts by default (configurable via `--max-reconnect-attempts`, 0 = unlimited)
+6. Exits immediately on auth errors (401/403) instead of retrying
 
 **Disabling color:**
 
@@ -180,8 +192,9 @@ internal/
   display/
     display.go                  Request logging and output helpers
     banner.go                   ASCII art banner on tunnel start
-    color.go                    Color primitives, TTY detection
+    color.go                    Color primitives, TTY detection, C1 sanitization
     errors.go                   Structured error types and printing
+    reconnect.go                Disconnection/reconnection status output
     spinner.go                  Animated spinner (TTY-aware)
   version/version.go            Build-time version variables
 ```
@@ -194,4 +207,4 @@ internal/
 4. CLI receives the frame, forwards the request to `localhost:<port>`, and sends the response back
 5. Server writes the response to the original caller
 6. Heartbeat pings every 30s keep the connection alive
-7. On disconnect, the CLI reconnects with exponential backoff (1s → 30s cap)
+7. On disconnect, the CLI reconnects with exponential backoff (1s -> 30s cap), up to 50 attempts by default. Auth errors (401/403) exit immediately.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/justtunnel/justtunnel-cli/internal/config"
@@ -21,9 +20,10 @@ import (
 )
 
 var (
-	cfgFile   string
-	logLevel  string
-	subdomain string
+	cfgFile              string
+	logLevel             string
+	subdomain            string
+	maxReconnectAttempts int
 )
 
 var rootCmd = &cobra.Command{
@@ -38,6 +38,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default ~/.config/justtunnel/config.yaml)")
 	rootCmd.Flags().StringVar(&logLevel, "log-level", "info", "log level (debug, info, warn, error)")
 	rootCmd.Flags().StringVarP(&subdomain, "subdomain", "s", "", "request a specific subdomain")
+	rootCmd.Flags().IntVar(&maxReconnectAttempts, "max-reconnect-attempts", 50, "maximum number of reconnection attempts (0 = unlimited)")
 	rootCmd.SilenceErrors = true
 	rootCmd.SilenceUsage = true
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
@@ -112,15 +113,38 @@ func runTunnel(cmd *cobra.Command, args []string) error {
 				reconnectSpinner.Update(msg)
 			}
 		},
-		OnReconnected: func() {
+		OnDisconnected: func(timestamp time.Time) {
 			if reconnectSpinner != nil {
-				reconnectSpinner.StopWithMessage(color.GreenString("✓") + " Reconnected")
+				reconnectSpinner.Stop()
 				reconnectSpinner = nil
 			}
+			display.PrintDisconnected(timestamp)
+		},
+		OnReconnected: func(info tunnel.ReconnectInfo) {
+			if reconnectSpinner != nil {
+				reconnectSpinner.Stop()
+				reconnectSpinner = nil
+			}
+			display.PrintReconnected(
+				info.Subdomain,
+				info.PreviousSubdomain,
+				info.TunnelURL,
+				info.LocalTarget,
+				info.SubdomainChanged,
+				info.DowntimeDuration,
+			)
 		},
 	}
 
 	tun := tunnel.New(serverURL, localTarget, cfg.AuthToken, logger, callbacks)
+
+	// Apply max reconnect attempts: CLI flag takes precedence, then config file.
+	// A config value of 0 means unlimited, which is valid and must not be ignored.
+	if cmd.Flags().Changed("max-reconnect-attempts") {
+		tun.SetMaxReconnectAttempts(maxReconnectAttempts)
+	} else if cfg.MaxReconnectAttempts != nil {
+		tun.SetMaxReconnectAttempts(*cfg.MaxReconnectAttempts)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,9 +11,10 @@ import (
 )
 
 type Config struct {
-	AuthToken string `mapstructure:"auth_token" yaml:"auth_token,omitempty"`
-	ServerURL string `mapstructure:"server_url" yaml:"server_url,omitempty"`
-	LogLevel  string `mapstructure:"log_level" yaml:"log_level,omitempty"`
+	AuthToken            string `mapstructure:"auth_token" yaml:"auth_token,omitempty"`
+	ServerURL            string `mapstructure:"server_url" yaml:"server_url,omitempty"`
+	LogLevel             string `mapstructure:"log_level" yaml:"log_level,omitempty"`
+	MaxReconnectAttempts *int   `mapstructure:"max_reconnect_attempts" yaml:"max_reconnect_attempts,omitempty"`
 }
 
 var configFilePath string

--- a/internal/display/color.go
+++ b/internal/display/color.go
@@ -46,12 +46,17 @@ func Bold(text string) string {
 }
 
 // sanitize strips terminal control characters from server-controlled strings
-// to prevent ANSI injection attacks.
+// to prevent ANSI injection attacks. This includes C0 controls (except tab),
+// ESC (0x1B), and C1 control codes (U+0080-U+009F) which many terminals
+// interpret as CSI sequences.
 func sanitize(text string) string {
 	var builder strings.Builder
 	builder.Grow(len(text))
 	for _, char := range text {
 		if char == '\033' || (char < 0x20 && char != '\t') {
+			continue
+		}
+		if char >= 0x80 && char <= 0x9F {
 			continue
 		}
 		builder.WriteRune(char)

--- a/internal/display/reconnect.go
+++ b/internal/display/reconnect.go
@@ -1,0 +1,41 @@
+package display
+
+import (
+	"fmt"
+	"time"
+)
+
+// PrintDisconnected prints a timestamped disconnection notice.
+func PrintDisconnected(timestamp time.Time) {
+	colorYellow.Fprintf(output, "  ⚠ Disconnected")
+	colorDim.Fprintf(output, " at %s\n", timestamp.Format("15:04:05"))
+}
+
+// PrintReconnected prints reconnection details including subdomain status and downtime.
+func PrintReconnected(subdomain, previousSubdomain, tunnelURL, localTarget string, subdomainChanged bool, downtime time.Duration) {
+	subdomain = sanitize(subdomain)
+	previousSubdomain = sanitize(previousSubdomain)
+	tunnelURL = sanitize(tunnelURL)
+	localTarget = sanitize(localTarget)
+
+	roundedDowntime := downtime.Round(time.Second)
+
+	colorGreen.Fprintf(output, "  ✓ Reconnected")
+	colorDim.Fprintf(output, " after %s\n", roundedDowntime)
+
+	if subdomainChanged {
+		colorYellow.Fprintf(output, "    ⚠ Subdomain changed: ")
+		fmt.Fprintf(output, "%s -> %s. Update your URLs.\n", previousSubdomain, subdomain)
+	}
+
+	colorCyan.Fprintf(output, "    %-12s", "Forwarding:")
+	colorWhite.Fprintf(output, " %s", tunnelURL)
+	colorDim.Fprintf(output, " -> ")
+	colorWhite.Fprintf(output, "%s\n", localTarget)
+
+	if !subdomainChanged {
+		colorCyan.Fprintf(output, "    %-12s", "Subdomain:")
+		colorWhite.Fprintf(output, " %s", subdomain)
+		colorDim.Fprintf(output, " (preserved)\n")
+	}
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -3,6 +3,7 @@ package tunnel
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -11,7 +12,19 @@ import (
 	"time"
 
 	"nhooyr.io/websocket"
+
+	"github.com/justtunnel/justtunnel-cli/internal/display"
 )
+
+// ReconnectInfo contains details about a successful reconnection.
+type ReconnectInfo struct {
+	Subdomain         string
+	PreviousSubdomain string
+	TunnelURL         string
+	LocalTarget       string
+	SubdomainChanged  bool
+	DowntimeDuration  time.Duration
+}
 
 type Callbacks struct {
 	OnConnecting    func()
@@ -19,7 +32,8 @@ type Callbacks struct {
 	OnRequest       func(method, path string, status int, latency time.Duration)
 	OnReconnecting  func(attempt int, backoff time.Duration)
 	OnReconnectWait func(attempt int, remaining time.Duration)
-	OnReconnected   func()
+	OnReconnected   func(info ReconnectInfo)
+	OnDisconnected  func(timestamp time.Time)
 }
 
 type Tunnel struct {
@@ -30,23 +44,37 @@ type Tunnel struct {
 	callbacks   Callbacks
 
 	conn   *websocket.Conn
-	connMu sync.Mutex // protects WebSocket writes
+	connMu sync.Mutex // protects conn field and WebSocket writes
 	wg     sync.WaitGroup
 
 	subdomain      string
 	tunnelURL      string
 	tunnelID       string
 	reconnectToken string
+
+	maxReconnectAttempts int
+	reconnecting         bool
+	disconnectedAt       time.Time
 }
 
 func New(serverURL, localTarget, authToken string, logger *slog.Logger, callbacks Callbacks) *Tunnel {
 	return &Tunnel{
-		serverURL:   serverURL,
-		localTarget: localTarget,
-		authToken:   authToken,
-		logger:      logger,
-		callbacks:   callbacks,
+		serverURL:            serverURL,
+		localTarget:          localTarget,
+		authToken:            authToken,
+		logger:               logger,
+		callbacks:            callbacks,
+		maxReconnectAttempts: 50,
 	}
+}
+
+// SetMaxReconnectAttempts sets the maximum number of reconnection attempts.
+// A value of 0 means unlimited attempts. Negative values are clamped to 0.
+func (t *Tunnel) SetMaxReconnectAttempts(maxAttempts int) {
+	if maxAttempts < 0 {
+		maxAttempts = 0
+	}
+	t.maxReconnectAttempts = maxAttempts
 }
 
 // Run is the main lifecycle: connect, read loop, reconnect on failure.
@@ -66,6 +94,11 @@ func (t *Tunnel) Run(ctx context.Context) error {
 		}
 		if err != nil {
 			t.logger.Error("connection lost", "error", err)
+			now := time.Now()
+			t.disconnectedAt = now
+			if t.callbacks.OnDisconnected != nil {
+				t.callbacks.OnDisconnected(now)
+			}
 			if reconnErr := t.reconnect(ctx); reconnErr != nil {
 				return reconnErr
 			}
@@ -85,8 +118,11 @@ func (t *Tunnel) connectWithURL(ctx context.Context, dialURL string) error {
 		}
 	}
 
-	conn, _, err := websocket.Dial(ctx, dialURL, opts)
+	conn, httpResp, err := websocket.Dial(ctx, dialURL, opts)
 	if err != nil {
+		if httpResp != nil && (httpResp.StatusCode == http.StatusUnauthorized || httpResp.StatusCode == http.StatusForbidden) {
+			return display.AuthError(fmt.Sprintf("server returned %d: %v", httpResp.StatusCode, err))
+		}
 		return fmt.Errorf("dial: %w", err)
 	}
 
@@ -122,7 +158,8 @@ func (t *Tunnel) connectWithURL(ctx context.Context, dialURL string) error {
 	t.tunnelID = assigned.TunnelID
 	t.reconnectToken = assigned.ReconnectToken
 
-	if t.callbacks.OnConnected != nil {
+	// Only fire OnConnected for the initial connection, not during reconnects.
+	if !t.reconnecting && t.callbacks.OnConnected != nil {
 		t.callbacks.OnConnected(assigned.Subdomain, assigned.URL, t.localTarget)
 	}
 
@@ -131,7 +168,11 @@ func (t *Tunnel) connectWithURL(ctx context.Context, dialURL string) error {
 
 func (t *Tunnel) readLoop(ctx context.Context) error {
 	for {
-		_, data, err := t.conn.Read(ctx)
+		t.connMu.Lock()
+		activeConn := t.conn
+		t.connMu.Unlock()
+
+		_, data, err := activeConn.Read(ctx)
 		if err != nil {
 			return fmt.Errorf("read: %w", err)
 		}
@@ -157,6 +198,11 @@ func (t *Tunnel) readLoop(ctx context.Context) error {
 func (t *Tunnel) handleRequest(ctx context.Context, frame *RequestFrame) {
 	defer t.wg.Done()
 
+	// Capture the active connection so we can detect if it changed during proxying.
+	t.connMu.Lock()
+	activeConn := t.conn
+	t.connMu.Unlock()
+
 	start := time.Now()
 	resp, err := ProxyRequest(ctx, *frame, t.localTarget, t.logger)
 	latency := time.Since(start)
@@ -168,7 +214,7 @@ func (t *Tunnel) handleRequest(ctx context.Context, frame *RequestFrame) {
 			ID:      frame.ID,
 			Message: "target unreachable",
 		}
-		if writeErr := t.writeJSON(ctx, errFrame); writeErr != nil {
+		if writeErr := t.writeJSONTo(ctx, activeConn, errFrame); writeErr != nil {
 			t.logger.Error("write error frame failed", "error", writeErr)
 		}
 		if t.callbacks.OnRequest != nil {
@@ -177,7 +223,7 @@ func (t *Tunnel) handleRequest(ctx context.Context, frame *RequestFrame) {
 		return
 	}
 
-	if err := t.writeJSON(ctx, resp); err != nil {
+	if err := t.writeJSONTo(ctx, activeConn, resp); err != nil {
 		t.logger.Error("write response failed", "id", frame.ID, "error", err)
 		return
 	}
@@ -187,14 +233,28 @@ func (t *Tunnel) handleRequest(ctx context.Context, frame *RequestFrame) {
 	}
 }
 
-func (t *Tunnel) writeJSON(ctx context.Context, v any) error {
+// writeJSONTo writes JSON to the specified connection, but only if it is still
+// the active connection. This prevents stale responses from being written to a
+// new connection after a reconnect.
+func (t *Tunnel) writeJSONTo(ctx context.Context, targetConn *websocket.Conn, v any) error {
 	data, err := json.Marshal(v)
 	if err != nil {
 		return fmt.Errorf("marshal: %w", err)
 	}
 	t.connMu.Lock()
 	defer t.connMu.Unlock()
+	if targetConn != t.conn {
+		t.logger.Warn("skipping write to stale connection")
+		return fmt.Errorf("connection replaced during request handling")
+	}
 	return t.conn.Write(ctx, websocket.MessageText, data)
+}
+
+// isAuthError checks if an error is an authentication/authorization failure
+// by checking if it wraps a display.CLIError with CategoryAuth.
+func isAuthError(err error) bool {
+	var cliErr *display.CLIError
+	return errors.As(err, &cliErr) && cliErr.Category == display.CategoryAuth
 }
 
 // buildReconnectURL appends reconnect token parameters to the server URL
@@ -231,10 +291,29 @@ func (t *Tunnel) reconnect(ctx context.Context) error {
 		t.logger.Warn("timed out waiting for in-flight requests before reconnect")
 	}
 
+	// Close old connection before attempting to dial a new one.
+	t.connMu.Lock()
+	if t.conn != nil {
+		t.conn.Close(websocket.StatusAbnormalClosure, "reconnecting")
+	}
+	t.connMu.Unlock()
+
+	t.reconnecting = true
+	previousSubdomain := t.subdomain
+
 	backoff := time.Second
 	const maxBackoff = 30 * time.Second
 
 	for attempt := 1; ; attempt++ {
+		// Check max reconnect attempts (0 = unlimited).
+		if t.maxReconnectAttempts > 0 && attempt > t.maxReconnectAttempts {
+			elapsed := time.Since(t.disconnectedAt).Round(time.Second)
+			return display.NetworkError(fmt.Sprintf(
+				"gave up reconnecting after %d attempts (disconnected for %s). Check your internet connection and restart the tunnel.",
+				attempt-1, elapsed,
+			))
+		}
+
 		if t.callbacks.OnReconnecting != nil {
 			t.callbacks.OnReconnecting(attempt, backoff)
 		}
@@ -246,6 +325,12 @@ func (t *Tunnel) reconnect(ctx context.Context) error {
 		reconnectURL := t.buildReconnectURL()
 		if err := t.connectWithURL(ctx, reconnectURL); err != nil {
 			t.logger.Error("reconnect attempt failed", "attempt", attempt, "error", err)
+
+			// Don't retry on auth errors — credentials won't change between attempts.
+			if isAuthError(err) {
+				return display.AuthError("authentication failed during reconnect - run 'justtunnel auth' to re-authenticate")
+			}
+
 			backoff *= 2
 			if backoff > maxBackoff {
 				backoff = maxBackoff
@@ -253,8 +338,18 @@ func (t *Tunnel) reconnect(ctx context.Context) error {
 			continue
 		}
 
+		t.reconnecting = false
+
 		if t.callbacks.OnReconnected != nil {
-			t.callbacks.OnReconnected()
+			info := ReconnectInfo{
+				Subdomain:         t.subdomain,
+				PreviousSubdomain: previousSubdomain,
+				TunnelURL:         t.tunnelURL,
+				LocalTarget:       t.localTarget,
+				SubdomainChanged:  t.subdomain != previousSubdomain,
+				DowntimeDuration:  time.Since(t.disconnectedAt),
+			}
+			t.callbacks.OnReconnected(info)
 		}
 		return nil
 	}


### PR DESCRIPTION
- add clear "Disconnected at HH:MM:SS" status on connection drop
- show reconnection status block with tunnel url, subdomain status, and downtime
- warn when subdomain changes on reconnect with "Update your URLs" guidance
- add max reconnect attempts (default 50, --max-reconnect-attempts flag)
- detect auth errors (401/403) and exit immediately instead of retrying
- fix race condition where stale responses could write to new connection
- close old connection before dialing new one on reconnect
- strip C1 control codes in sanitize() to prevent terminal injection