### PR TITLE
password-protected tunnels

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ var (
 	cfgFile              string
 	logLevel             string
 	subdomain            string
+	password             string
 	maxReconnectAttempts int
 	tunnelConfigFile     string
 )
@@ -47,6 +48,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&subdomain, "subdomain", "s", "", "request a specific subdomain")
 	rootCmd.Flags().IntVar(&maxReconnectAttempts, "max-reconnect-attempts", 50, "maximum number of reconnection attempts (0 = unlimited)")
 	rootCmd.Flags().StringVar(&tunnelConfigFile, "config-file", "", "YAML config file with tunnel definitions")
+	rootCmd.Flags().StringVar(&password, "password", "", "password-protect the tunnel (4-128 chars)")
 	rootCmd.SilenceErrors = true
 	rootCmd.SilenceUsage = true
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
@@ -68,6 +70,13 @@ func runTunnel(cmd *cobra.Command, args []string) error {
 		port, parseErr = strconv.Atoi(args[0])
 		if parseErr != nil || port < 1 || port > 65535 {
 			return display.InputError(fmt.Sprintf("invalid port: %s (must be 1-65535)", args[0]))
+		}
+	}
+
+	// Validate password length if provided
+	if password != "" {
+		if len(password) < 4 || len(password) > 128 {
+			return display.InputError("password must be between 4 and 128 characters")
 		}
 	}
 
@@ -175,7 +184,7 @@ func runTUI(port int, cfg *config.Config, serverURL string, logger *slog.Logger,
 	// Start the initial tunnel via the manager
 	if port > 0 {
 		initialName := fmt.Sprintf(":%d", port)
-		if addErr := manager.Add(port, initialName, subdomain); addErr != nil {
+		if addErr := manager.Add(port, initialName, subdomain, password); addErr != nil {
 			return fmt.Errorf("start initial tunnel: %w", addErr)
 		}
 	}
@@ -185,7 +194,7 @@ func runTUI(port int, cfg *config.Config, serverURL string, logger *slog.Logger,
 		if preset.Port == port {
 			continue
 		}
-		if addErr := manager.Add(preset.Port, preset.Name, preset.Subdomain); addErr != nil {
+		if addErr := manager.Add(preset.Port, preset.Name, preset.Subdomain, preset.Password); addErr != nil {
 			logger.Warn("could not start config tunnel", "port", preset.Port, "error", addErr)
 		}
 	}
@@ -231,7 +240,7 @@ func (ps *programSender) Send(msg tea.Msg) {
 // newTunnelFactory creates a tui.TunnelFactory that produces real tunnel.Tunnel
 // instances wired to the TUI callback system.
 func newTunnelFactory(serverURL, authToken string, logger *slog.Logger, cmd *cobra.Command) tui.TunnelFactory {
-	return func(port int, name string, tunnelSubdomain string, callbacks tui.TunnelCallbacks) tui.TunnelRunner {
+	return func(port int, name string, tunnelSubdomain string, tunnelPassword string, callbacks tui.TunnelCallbacks) tui.TunnelRunner {
 		localTarget := fmt.Sprintf("http://localhost:%d", port)
 
 		// Build the server URL with an optional subdomain for this tunnel
@@ -244,9 +253,9 @@ func newTunnelFactory(serverURL, authToken string, logger *slog.Logger, cmd *cob
 
 		// Bridge TUI callbacks to tunnel.Callbacks
 		tunnelCallbacks := tunnel.Callbacks{
-			OnConnected: func(sub, tunnelURL, target string) {
+			OnConnected: func(sub, tunnelURL, target string, passwordProtected bool) {
 				if callbacks.OnConnected != nil {
-					callbacks.OnConnected(sub, tunnelURL, target)
+					callbacks.OnConnected(sub, tunnelURL, target, passwordProtected)
 				}
 			},
 			OnRequest: func(method, path string, status int, latency time.Duration) {
@@ -278,6 +287,10 @@ func newTunnelFactory(serverURL, authToken string, logger *slog.Logger, cmd *cob
 
 		tun := tunnel.New(dialURL, localTarget, authToken, logger, tunnelCallbacks)
 
+		if tunnelPassword != "" {
+			tun.SetPassword(tunnelPassword)
+		}
+
 		// Apply max reconnect attempts
 		if cmd.Flags().Changed("max-reconnect-attempts") {
 			tun.SetMaxReconnectAttempts(maxReconnectAttempts)
@@ -300,7 +313,7 @@ func runNonTTY(port int, cfg *config.Config, serverURL string, logger *slog.Logg
 			connectSpinner = display.NewSpinner("Connecting...")
 			connectSpinner.Start()
 		},
-		OnConnected: func(sub, tunnelURL, target string) {
+		OnConnected: func(sub, tunnelURL, target string, passwordProtected bool) {
 			if connectSpinner != nil {
 				connectSpinner.Stop()
 				connectSpinner = nil
@@ -348,6 +361,10 @@ func runNonTTY(port int, cfg *config.Config, serverURL string, logger *slog.Logg
 	}
 
 	tun := tunnel.New(serverURL, localTarget, cfg.AuthToken, logger, callbacks)
+
+	if password != "" {
+		tun.SetPassword(password)
+	}
 
 	// Apply max reconnect attempts: CLI flag takes precedence, then config file.
 	// A config value of 0 means unlimited, which is valid and must not be ignored.

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -13,11 +13,12 @@ type Command interface {
 }
 
 // AddCommand represents a parsed /add command with a validated port
-// and optional name/subdomain flags.
+// and optional name/subdomain/password flags.
 type AddCommand struct {
 	Port      int
 	Name      string
 	Subdomain string
+	Password  string
 }
 
 func (AddCommand) commandType() string { return "add" }
@@ -77,10 +78,10 @@ func ParseCommand(input string) (Command, error) {
 	}
 }
 
-// parseAddCommand parses the arguments for /add: <port> [--name <name>] [--subdomain <subdomain>].
+// parseAddCommand parses the arguments for /add: <port> [--name <name>] [--subdomain <subdomain>] [--password <password>].
 func parseAddCommand(args []string) (Command, error) {
 	if len(args) == 0 {
-		return nil, fmt.Errorf("Usage: /add <port> [--name <name>] [--subdomain <subdomain>]")
+		return nil, fmt.Errorf("Usage: /add <port> [--name <name>] [--subdomain <subdomain>] [--password <password>]")
 	}
 
 	portStr := args[0]
@@ -97,16 +98,22 @@ func parseAddCommand(args []string) (Command, error) {
 		switch flagArgs[idx] {
 		case "--name":
 			if idx+1 >= len(flagArgs) {
-				return nil, fmt.Errorf("Usage: /add <port> [--name <name>] [--subdomain <subdomain>]")
+				return nil, fmt.Errorf("Usage: /add <port> [--name <name>] [--subdomain <subdomain>] [--password <password>]")
 			}
 			idx++
 			cmd.Name = flagArgs[idx]
 		case "--subdomain":
 			if idx+1 >= len(flagArgs) {
-				return nil, fmt.Errorf("Usage: /add <port> [--name <name>] [--subdomain <subdomain>]")
+				return nil, fmt.Errorf("Usage: /add <port> [--name <name>] [--subdomain <subdomain>] [--password <password>]")
 			}
 			idx++
 			cmd.Subdomain = flagArgs[idx]
+		case "--password":
+			if idx+1 >= len(flagArgs) {
+				return nil, fmt.Errorf("Usage: /add <port> [--name <name>] [--subdomain <subdomain>] [--password <password>]")
+			}
+			idx++
+			cmd.Password = flagArgs[idx]
 		}
 	}
 

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -51,6 +51,23 @@ func TestParseCommand(t *testing.T) {
 			wantCmd: AddCommand{Port: 65535},
 		},
 
+		// /add with --password flag
+		{
+			name:    "add with password flag",
+			input:   "/add 8080 --password secret123",
+			wantCmd: AddCommand{Port: 8080, Password: "secret123"},
+		},
+		{
+			name:    "add with all flags including password",
+			input:   "/add 8080 --name api --subdomain my-api --password mypass",
+			wantCmd: AddCommand{Port: 8080, Name: "api", Subdomain: "my-api", Password: "mypass"},
+		},
+		{
+			name:    "add with password in different order",
+			input:   "/add 8080 --password pw1234 --name api",
+			wantCmd: AddCommand{Port: 8080, Name: "api", Password: "pw1234"},
+		},
+
 		// Case-insensitive commands
 		{
 			name:    "add uppercase",
@@ -155,7 +172,7 @@ func TestParseCommand(t *testing.T) {
 			name:       "add missing port",
 			input:      "/add",
 			wantErr:    true,
-			wantErrMsg: "Usage: /add <port> [--name <name>] [--subdomain <subdomain>]",
+			wantErrMsg: "Usage: /add <port> [--name <name>] [--subdomain <subdomain>] [--password <password>]",
 		},
 		{
 			name:       "remove missing target",
@@ -216,6 +233,9 @@ func TestParseCommand(t *testing.T) {
 				}
 				if got.Subdomain != expected.Subdomain {
 					t.Errorf("Subdomain = %q, want %q", got.Subdomain, expected.Subdomain)
+				}
+				if got.Password != expected.Password {
+					t.Errorf("Password = %q, want %q", got.Password, expected.Password)
 				}
 
 			case RemoveCommand:

--- a/internal/tui/config.go
+++ b/internal/tui/config.go
@@ -53,6 +53,14 @@ func validateConfig(cfg *TunnelPresetConfig) error {
 			return fmt.Errorf("tunnel[%d]: duplicate port %d", idx, preset.Port)
 		}
 		seenPorts[preset.Port] = true
+
+		if preset.Password != "" && (len(preset.Password) < 4 || len(preset.Password) > 128) {
+			name := preset.Name
+			if name == "" {
+				name = fmt.Sprintf("port %d", preset.Port)
+			}
+			return fmt.Errorf("tunnel %q password must be between 4 and 128 characters", name)
+		}
 	}
 
 	return nil

--- a/internal/tui/config_test.go
+++ b/internal/tui/config_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -116,6 +117,134 @@ func TestLoadConfig(t *testing.T) {
 				t.Errorf("got %d tunnels, want %d", len(cfg.Tunnels), tt.wantTunnels)
 			}
 		})
+	}
+}
+
+func TestLoadConfig_PasswordField(t *testing.T) {
+	t.Parallel()
+
+	yamlContent := `tunnels:
+  - port: 3000
+    name: frontend
+    password: mysecret
+  - port: 8080
+    name: api
+`
+	configPath := writeTestConfig(t, yamlContent)
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Tunnels) != 2 {
+		t.Fatalf("got %d tunnels, want 2", len(cfg.Tunnels))
+	}
+	if cfg.Tunnels[0].Password != "mysecret" {
+		t.Errorf("first tunnel password = %q, want %q", cfg.Tunnels[0].Password, "mysecret")
+	}
+	if cfg.Tunnels[1].Password != "" {
+		t.Errorf("second tunnel password = %q, want empty", cfg.Tunnels[1].Password)
+	}
+}
+
+func TestLoadConfig_PasswordValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{
+			name: "valid password (4 chars)",
+			yaml: `tunnels:
+  - port: 3000
+    name: frontend
+    password: abcd
+`,
+			wantErr: false,
+		},
+		{
+			name: "password too short (3 chars)",
+			yaml: `tunnels:
+  - port: 3000
+    name: frontend
+    password: abc
+`,
+			wantErr: true,
+		},
+		{
+			name: "password too short (1 char)",
+			yaml: `tunnels:
+  - port: 3000
+    name: frontend
+    password: x
+`,
+			wantErr: true,
+		},
+		{
+			name: "empty password is valid (means no password)",
+			yaml: `tunnels:
+  - port: 3000
+    name: frontend
+`,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			configPath := writeTestConfig(t, tt.yaml)
+
+			_, err := LoadConfig(configPath)
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_PasswordTooShortErrorIncludesName(t *testing.T) {
+	t.Parallel()
+
+	yamlContent := `tunnels:
+  - port: 3000
+    name: frontend
+    password: ab
+`
+	configPath := writeTestConfig(t, yamlContent)
+
+	_, err := LoadConfig(configPath)
+	if err == nil {
+		t.Fatal("expected error for short password, got nil")
+	}
+	if !strings.Contains(err.Error(), "frontend") {
+		t.Errorf("error should mention tunnel name, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "password must be between 4 and 128") {
+		t.Errorf("error should mention password length requirement, got: %v", err)
+	}
+}
+
+func TestLoadConfig_PasswordTooShortUsesPortWhenNoName(t *testing.T) {
+	t.Parallel()
+
+	yamlContent := `tunnels:
+  - port: 3000
+    password: ab
+`
+	configPath := writeTestConfig(t, yamlContent)
+
+	_, err := LoadConfig(configPath)
+	if err == nil {
+		t.Fatal("expected error for short password, got nil")
+	}
+	if !strings.Contains(err.Error(), "port 3000") {
+		t.Errorf("error should mention port when no name is set, got: %v", err)
 	}
 }
 

--- a/internal/tui/integration_test.go
+++ b/internal/tui/integration_test.go
@@ -18,11 +18,11 @@ func TestMultiTunnelSpawn(t *testing.T) {
 	mocks := make(map[int]*mockTunnel)
 	mgr := NewTunnelManager(mockTunnelFactory(mocks), collector)
 
-	err := mgr.Add(3000, "api", "")
+	err := mgr.Add(3000, "api", "", "")
 	if err != nil {
 		t.Fatalf("Add(3000) failed: %v", err)
 	}
-	err = mgr.Add(8080, "web", "")
+	err = mgr.Add(8080, "web", "", "")
 	if err != nil {
 		t.Fatalf("Add(8080) failed: %v", err)
 	}
@@ -86,10 +86,10 @@ func TestMultiTunnelSpawnWithModelView(t *testing.T) {
 
 	// Simulate both tunnels connecting
 	managed3000 := mgr.getManagedTunnel(3000)
-	managed3000.Callbacks.OnConnected("api-sub", "https://api-sub.justtunnel.dev", "localhost:3000")
+	managed3000.Callbacks.OnConnected("api-sub", "https://api-sub.justtunnel.dev", "localhost:3000", false)
 
 	managed8080 := mgr.getManagedTunnel(8080)
-	managed8080.Callbacks.OnConnected("web-sub", "https://web-sub.justtunnel.dev", "localhost:8080")
+	managed8080.Callbacks.OnConnected("web-sub", "https://web-sub.justtunnel.dev", "localhost:8080", false)
 
 	// Process the TunnelConnectedMsg messages through the model
 	for _, msg := range collector.Messages() {
@@ -163,11 +163,11 @@ func TestReconnectionIndependence(t *testing.T) {
 	mgr := NewTunnelManager(mockTunnelFactory(mocks), collector)
 
 	// Add and connect two tunnels
-	err := mgr.Add(3000, "api", "")
+	err := mgr.Add(3000, "api", "", "")
 	if err != nil {
 		t.Fatalf("Add(3000) failed: %v", err)
 	}
-	err = mgr.Add(8080, "web", "")
+	err = mgr.Add(8080, "web", "", "")
 	if err != nil {
 		t.Fatalf("Add(8080) failed: %v", err)
 	}
@@ -176,8 +176,8 @@ func TestReconnectionIndependence(t *testing.T) {
 	managedWeb := mgr.getManagedTunnel(8080)
 
 	// Both connect successfully
-	managedAPI.Callbacks.OnConnected("api-sub", "https://api-sub.justtunnel.dev", "localhost:3000")
-	managedWeb.Callbacks.OnConnected("web-sub", "https://web-sub.justtunnel.dev", "localhost:8080")
+	managedAPI.Callbacks.OnConnected("api-sub", "https://api-sub.justtunnel.dev", "localhost:3000", false)
+	managedWeb.Callbacks.OnConnected("web-sub", "https://web-sub.justtunnel.dev", "localhost:8080", false)
 
 	// Verify both connected
 	if managedAPI.State != StateConnected {
@@ -217,14 +217,14 @@ func TestGracefulShutdownMultipleTunnels(t *testing.T) {
 	mgr := NewTunnelManager(mockTunnelFactory(mocks), collector)
 
 	// Add and connect two tunnels
-	_ = mgr.Add(3000, "api", "")
-	_ = mgr.Add(8080, "web", "")
+	_ = mgr.Add(3000, "api", "", "")
+	_ = mgr.Add(8080, "web", "", "")
 
 	managedAPI := mgr.getManagedTunnel(3000)
 	managedWeb := mgr.getManagedTunnel(8080)
 
-	managedAPI.Callbacks.OnConnected("api-sub", "https://api-sub.justtunnel.dev", "localhost:3000")
-	managedWeb.Callbacks.OnConnected("web-sub", "https://web-sub.justtunnel.dev", "localhost:8080")
+	managedAPI.Callbacks.OnConnected("api-sub", "https://api-sub.justtunnel.dev", "localhost:3000", false)
+	managedWeb.Callbacks.OnConnected("web-sub", "https://web-sub.justtunnel.dev", "localhost:8080", false)
 
 	// Verify tunnels are running
 	if mgr.Count() != 2 {
@@ -257,11 +257,11 @@ func TestSubdomainChangeOnReconnectResetsStats(t *testing.T) {
 		collector := newMsgCollector()
 		mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
 
-		_ = mgr.Add(8080, "web", "")
+		_ = mgr.Add(8080, "web", "", "")
 		managed := mgr.getManagedTunnel(8080)
 
 		// Connect and record some requests
-		managed.Callbacks.OnConnected("old-sub", "https://old-sub.justtunnel.dev", "localhost:8080")
+		managed.Callbacks.OnConnected("old-sub", "https://old-sub.justtunnel.dev", "localhost:8080", false)
 		managed.Callbacks.OnRequest("GET", "/api/users", 200, 25*time.Millisecond)
 		managed.Callbacks.OnRequest("POST", "/api/data", 201, 50*time.Millisecond)
 
@@ -310,11 +310,11 @@ func TestSubdomainChangeOnReconnectResetsStats(t *testing.T) {
 		collector := newMsgCollector()
 		mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
 
-		_ = mgr.Add(8080, "web", "")
+		_ = mgr.Add(8080, "web", "", "")
 		managed := mgr.getManagedTunnel(8080)
 
 		// Connect and record requests
-		managed.Callbacks.OnConnected("my-sub", "https://my-sub.justtunnel.dev", "localhost:8080")
+		managed.Callbacks.OnConnected("my-sub", "https://my-sub.justtunnel.dev", "localhost:8080", false)
 		managed.Callbacks.OnRequest("GET", "/health", 200, 5*time.Millisecond)
 		managed.Callbacks.OnRequest("GET", "/status", 200, 8*time.Millisecond)
 		managed.Callbacks.OnRequest("POST", "/webhook", 200, 12*time.Millisecond)
@@ -349,7 +349,7 @@ func TestConcurrentTunnelOperations(t *testing.T) {
 		wg.Add(1)
 		go func(port int) {
 			defer wg.Done()
-			_ = mgr.Add(port, "svc", "")
+			_ = mgr.Add(port, "svc", "", "")
 		}(10000 + portOffset)
 	}
 	wg.Wait()
@@ -388,15 +388,15 @@ func TestMultiTunnelCallbackIsolation(t *testing.T) {
 	collector := newMsgCollector()
 	mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
 
-	_ = mgr.Add(3000, "api", "")
-	_ = mgr.Add(8080, "web", "")
+	_ = mgr.Add(3000, "api", "", "")
+	_ = mgr.Add(8080, "web", "", "")
 
 	managedAPI := mgr.getManagedTunnel(3000)
 	managedWeb := mgr.getManagedTunnel(8080)
 
 	// Connect both
-	managedAPI.Callbacks.OnConnected("api-sub", "https://api-sub.justtunnel.dev", "localhost:3000")
-	managedWeb.Callbacks.OnConnected("web-sub", "https://web-sub.justtunnel.dev", "localhost:8080")
+	managedAPI.Callbacks.OnConnected("api-sub", "https://api-sub.justtunnel.dev", "localhost:3000", false)
+	managedWeb.Callbacks.OnConnected("web-sub", "https://web-sub.justtunnel.dev", "localhost:8080", false)
 
 	// Record requests only on the API tunnel
 	managedAPI.Callbacks.OnRequest("GET", "/api/users", 200, 10*time.Millisecond)
@@ -430,15 +430,15 @@ func TestReconnectingStateDoesNotAffectOtherTunnels(t *testing.T) {
 	collector := newMsgCollector()
 	mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
 
-	_ = mgr.Add(3000, "api", "")
-	_ = mgr.Add(8080, "web", "")
+	_ = mgr.Add(3000, "api", "", "")
+	_ = mgr.Add(8080, "web", "", "")
 
 	managedAPI := mgr.getManagedTunnel(3000)
 	managedWeb := mgr.getManagedTunnel(8080)
 
 	// Both connect
-	managedAPI.Callbacks.OnConnected("api-sub", "https://api-sub.justtunnel.dev", "localhost:3000")
-	managedWeb.Callbacks.OnConnected("web-sub", "https://web-sub.justtunnel.dev", "localhost:8080")
+	managedAPI.Callbacks.OnConnected("api-sub", "https://api-sub.justtunnel.dev", "localhost:3000", false)
+	managedWeb.Callbacks.OnConnected("web-sub", "https://web-sub.justtunnel.dev", "localhost:8080", false)
 
 	// API tunnel starts reconnecting
 	managedAPI.Callbacks.OnDisconnected(time.Now())
@@ -490,8 +490,8 @@ func TestFullLifecycleIntegration(t *testing.T) {
 	managed3000 := mgr.getManagedTunnel(3000)
 	managed8080 := mgr.getManagedTunnel(8080)
 
-	managed3000.Callbacks.OnConnected("api-sub", "https://api-sub.justtunnel.dev", "localhost:3000")
-	managed8080.Callbacks.OnConnected("web-sub", "https://web-sub.justtunnel.dev", "localhost:8080")
+	managed3000.Callbacks.OnConnected("api-sub", "https://api-sub.justtunnel.dev", "localhost:3000", false)
+	managed8080.Callbacks.OnConnected("web-sub", "https://web-sub.justtunnel.dev", "localhost:8080", false)
 
 	// Process connected messages
 	for _, msg := range collector.Messages() {

--- a/internal/tui/managed_tunnel.go
+++ b/internal/tui/managed_tunnel.go
@@ -18,16 +18,16 @@ type TunnelRunner interface {
 // TunnelCallbacks holds the callback functions that the manager wires
 // into each tunnel to bridge lifecycle events to Bubble Tea messages.
 type TunnelCallbacks struct {
-	OnConnected    func(subdomain, url, localTarget string)
+	OnConnected    func(subdomain, url, localTarget string, passwordProtected bool)
 	OnDisconnected func(timestamp time.Time)
 	OnReconnecting func(attempt int, backoff time.Duration)
 	OnReconnected  func(subdomain, previousSubdomain, tunnelURL string, subdomainChanged bool)
 	OnRequest      func(method, path string, status int, latency time.Duration)
 }
 
-// TunnelFactory creates a TunnelRunner given the port, name, subdomain, and callbacks.
+// TunnelFactory creates a TunnelRunner given the port, name, subdomain, password, and callbacks.
 // In production this creates a real tunnel.Tunnel; in tests it returns a mock.
-type TunnelFactory func(port int, name string, subdomain string, callbacks TunnelCallbacks) TunnelRunner
+type TunnelFactory func(port int, name string, subdomain string, password string, callbacks TunnelCallbacks) TunnelRunner
 
 // MessageSender abstracts tea.Program.Send() so the manager can bridge
 // tunnel callbacks to the TUI without depending on a real Bubble Tea program.
@@ -45,15 +45,16 @@ type ManagedTunnel struct {
 	Source string
 
 	// mu protects mutable fields written by callbacks from the tunnel goroutine.
-	mu            sync.RWMutex
-	Subdomain     string
-	LastSubdomain string
-	PublicURL     string
-	State         TunnelState
-	Error         string
-	ConnectedAt   time.Time
-	Stats         *RequestStats
-	Callbacks     TunnelCallbacks
+	mu                sync.RWMutex
+	Subdomain         string
+	LastSubdomain     string
+	PublicURL         string
+	State             TunnelState
+	Error             string
+	ConnectedAt       time.Time
+	PasswordProtected bool
+	Stats             *RequestStats
+	Callbacks         TunnelCallbacks
 
 	runner TunnelRunner
 	cancel context.CancelFunc
@@ -101,6 +102,7 @@ func newManagedTunnel(
 	port int,
 	name string,
 	subdomain string,
+	password string,
 	factory TunnelFactory,
 	sender MessageSender,
 ) *ManagedTunnel {
@@ -113,18 +115,20 @@ func newManagedTunnel(
 	}
 
 	callbacks := TunnelCallbacks{
-		OnConnected: func(sub, tunnelURL, localTarget string) {
+		OnConnected: func(sub, tunnelURL, localTarget string, passwordProtected bool) {
 			managed.mu.Lock()
 			managed.Subdomain = sub
 			managed.PublicURL = tunnelURL
 			managed.State = StateConnected
 			managed.ConnectedAt = time.Now()
+			managed.PasswordProtected = passwordProtected
 			managed.mu.Unlock()
 			if sender != nil {
 				sender.Send(TunnelConnectedMsg{
-					Port:      port,
-					Subdomain: sub,
-					PublicURL: tunnelURL,
+					Port:              port,
+					Subdomain:         sub,
+					PublicURL:         tunnelURL,
+					PasswordProtected: passwordProtected,
 				})
 			}
 		},
@@ -176,7 +180,7 @@ func newManagedTunnel(
 	}
 
 	managed.Callbacks = callbacks
-	managed.runner = factory(port, name, subdomain, callbacks)
+	managed.runner = factory(port, name, subdomain, password, callbacks)
 
 	return managed
 }

--- a/internal/tui/manager.go
+++ b/internal/tui/manager.go
@@ -44,7 +44,7 @@ func NewTunnelManager(factory TunnelFactory, sender MessageSender) *TunnelManage
 
 // Add creates and starts a new tunnel on the given port.
 // Returns an error if the port is invalid or already in use.
-func (m *TunnelManager) Add(port int, name string, subdomain string) error {
+func (m *TunnelManager) Add(port int, name string, subdomain string, password string) error {
 	if port < minPort || port > maxPort {
 		return fmt.Errorf("invalid port %d: must be between %d and %d", port, minPort, maxPort)
 	}
@@ -56,7 +56,7 @@ func (m *TunnelManager) Add(port int, name string, subdomain string) error {
 		return fmt.Errorf("tunnel already running on port %d", port)
 	}
 
-	managed := newManagedTunnel(port, name, subdomain, m.factory, m.sender)
+	managed := newManagedTunnel(port, name, subdomain, password, m.factory, m.sender)
 	m.tunnelsByPort[port] = managed
 	m.insertionOrder = append(m.insertionOrder, port)
 

--- a/internal/tui/manager_test.go
+++ b/internal/tui/manager_test.go
@@ -85,7 +85,7 @@ func (mc *msgCollector) Messages() []tea.Msg {
 
 // mockTunnelFactory creates a factory that produces mockTunnels and records them.
 func mockTunnelFactory(mocks map[int]*mockTunnel) TunnelFactory {
-	return func(port int, name string, subdomain string, callbacks TunnelCallbacks) TunnelRunner {
+	return func(port int, name string, subdomain string, password string, callbacks TunnelCallbacks) TunnelRunner {
 		mock := newMockTunnel(port)
 		if mocks != nil {
 			mocks[port] = mock
@@ -97,7 +97,7 @@ func mockTunnelFactory(mocks map[int]*mockTunnel) TunnelFactory {
 // mockTunnelFactoryWithError creates a factory that produces mockTunnels
 // pre-configured to return the given error from Run().
 func mockTunnelFactoryWithError(runErr error, mocks map[int]*mockTunnel) TunnelFactory {
-	return func(port int, name string, subdomain string, callbacks TunnelCallbacks) TunnelRunner {
+	return func(port int, name string, subdomain string, password string, callbacks TunnelCallbacks) TunnelRunner {
 		mock := newMockTunnel(port)
 		mock.runErr = runErr
 		if mocks != nil {
@@ -111,7 +111,7 @@ func TestManagerAddTunnel(t *testing.T) {
 	t.Run("add tunnel appears in list with correct port and state", func(t *testing.T) {
 		mgr := NewTunnelManager(mockTunnelFactory(nil), nil)
 
-		err := mgr.Add(8080, "web", "")
+		err := mgr.Add(8080, "web", "", "")
 		if err != nil {
 			t.Fatalf("Add(8080) returned unexpected error: %v", err)
 		}
@@ -135,9 +135,9 @@ func TestManagerAddTunnel(t *testing.T) {
 	t.Run("add multiple tunnels in insertion order", func(t *testing.T) {
 		mgr := NewTunnelManager(mockTunnelFactory(nil), nil)
 
-		_ = mgr.Add(3000, "api", "")
-		_ = mgr.Add(8080, "web", "")
-		_ = mgr.Add(5432, "db", "")
+		_ = mgr.Add(3000, "api", "", "")
+		_ = mgr.Add(8080, "web", "", "")
+		_ = mgr.Add(5432, "db", "", "")
 
 		tunnels := mgr.Tunnels()
 		if len(tunnels) != 3 {
@@ -156,12 +156,12 @@ func TestManagerAddTunnel(t *testing.T) {
 func TestManagerAddDuplicatePort(t *testing.T) {
 	mgr := NewTunnelManager(mockTunnelFactory(nil), nil)
 
-	err := mgr.Add(8080, "web", "")
+	err := mgr.Add(8080, "web", "", "")
 	if err != nil {
 		t.Fatalf("first Add(8080) failed: %v", err)
 	}
 
-	err = mgr.Add(8080, "web2", "")
+	err = mgr.Add(8080, "web2", "", "")
 	if err == nil {
 		t.Fatal("expected error for duplicate port, got nil")
 	}
@@ -187,7 +187,7 @@ func TestManagerAddInvalidPort(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mgr := NewTunnelManager(mockTunnelFactory(nil), nil)
-			err := mgr.Add(tt.port, "", "")
+			err := mgr.Add(tt.port, "", "", "")
 			if err == nil {
 				t.Errorf("expected error for port %d, got nil", tt.port)
 			}
@@ -199,9 +199,9 @@ func TestManagerRemoveByIndex(t *testing.T) {
 	mocks := make(map[int]*mockTunnel)
 	mgr := NewTunnelManager(mockTunnelFactory(mocks), nil)
 
-	_ = mgr.Add(3000, "api", "")
-	_ = mgr.Add(8080, "web", "")
-	_ = mgr.Add(5432, "db", "")
+	_ = mgr.Add(3000, "api", "", "")
+	_ = mgr.Add(8080, "web", "", "")
+	_ = mgr.Add(5432, "db", "", "")
 
 	// Remove index 2 (1-based) = port 8080
 	err := mgr.RemoveByIndex(2)
@@ -227,8 +227,8 @@ func TestManagerRemoveByPort(t *testing.T) {
 	mocks := make(map[int]*mockTunnel)
 	mgr := NewTunnelManager(mockTunnelFactory(mocks), nil)
 
-	_ = mgr.Add(3000, "api", "")
-	_ = mgr.Add(8080, "web", "")
+	_ = mgr.Add(3000, "api", "", "")
+	_ = mgr.Add(8080, "web", "", "")
 
 	err := mgr.RemoveByPort(3000)
 	if err != nil {
@@ -246,7 +246,7 @@ func TestManagerRemoveByPort(t *testing.T) {
 
 func TestManagerRemoveNonExistentIndex(t *testing.T) {
 	mgr := NewTunnelManager(mockTunnelFactory(nil), nil)
-	_ = mgr.Add(8080, "web", "")
+	_ = mgr.Add(8080, "web", "", "")
 
 	err := mgr.RemoveByIndex(5)
 	if err == nil {
@@ -261,7 +261,7 @@ func TestManagerRemoveNonExistentIndex(t *testing.T) {
 
 func TestManagerRemoveNonExistentPort(t *testing.T) {
 	mgr := NewTunnelManager(mockTunnelFactory(nil), nil)
-	_ = mgr.Add(8080, "web", "")
+	_ = mgr.Add(8080, "web", "", "")
 
 	err := mgr.RemoveByPort(9999)
 	if err == nil {
@@ -273,8 +273,8 @@ func TestManagerShutdownAll(t *testing.T) {
 	mocks := make(map[int]*mockTunnel)
 	mgr := NewTunnelManager(mockTunnelFactory(mocks), nil)
 
-	_ = mgr.Add(3000, "api", "")
-	_ = mgr.Add(8080, "web", "")
+	_ = mgr.Add(3000, "api", "", "")
+	_ = mgr.Add(8080, "web", "", "")
 
 	mgr.Shutdown()
 
@@ -288,7 +288,7 @@ func TestManagerCountAfterRemoveAll(t *testing.T) {
 	mocks := make(map[int]*mockTunnel)
 	mgr := NewTunnelManager(mockTunnelFactory(mocks), nil)
 
-	_ = mgr.Add(8080, "web", "")
+	_ = mgr.Add(8080, "web", "", "")
 
 	err := mgr.RemoveByPort(8080)
 	if err != nil {
@@ -306,7 +306,7 @@ func TestManagerTunnelsStableInsertionOrder(t *testing.T) {
 
 	ports := []int{9090, 3000, 8080, 4000, 5000}
 	for _, port := range ports {
-		_ = mgr.Add(port, fmt.Sprintf("svc-%d", port), "")
+		_ = mgr.Add(port, fmt.Sprintf("svc-%d", port), "", "")
 	}
 
 	tunnels := mgr.Tunnels()
@@ -333,14 +333,14 @@ func TestManagerCallbackBridge(t *testing.T) {
 		collector := newMsgCollector()
 		mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
 
-		_ = mgr.Add(8080, "web", "")
+		_ = mgr.Add(8080, "web", "", "")
 
 		// Simulate the connected callback
 		managed := mgr.getManagedTunnel(8080)
 		if managed == nil {
 			t.Fatal("expected managed tunnel for port 8080")
 		}
-		managed.Callbacks.OnConnected("test-sub", "https://test-sub.justtunnel.dev", "localhost:8080")
+		managed.Callbacks.OnConnected("test-sub", "https://test-sub.justtunnel.dev", "localhost:8080", false)
 
 		msgs := collector.Messages()
 		if len(msgs) == 0 {
@@ -363,7 +363,7 @@ func TestManagerCallbackBridge(t *testing.T) {
 		collector := newMsgCollector()
 		mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
 
-		_ = mgr.Add(8080, "web", "")
+		_ = mgr.Add(8080, "web", "", "")
 
 		managed := mgr.getManagedTunnel(8080)
 		now := time.Now()
@@ -386,7 +386,7 @@ func TestManagerCallbackBridge(t *testing.T) {
 		collector := newMsgCollector()
 		mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
 
-		_ = mgr.Add(8080, "web", "")
+		_ = mgr.Add(8080, "web", "", "")
 
 		managed := mgr.getManagedTunnel(8080)
 		managed.Callbacks.OnReconnecting(3, 4*time.Second)
@@ -410,7 +410,7 @@ func TestManagerCallbackBridge(t *testing.T) {
 		collector := newMsgCollector()
 		mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
 
-		_ = mgr.Add(8080, "web", "")
+		_ = mgr.Add(8080, "web", "", "")
 
 		managed := mgr.getManagedTunnel(8080)
 		managed.Callbacks.OnRequest("GET", "/api/users", 200, 50*time.Millisecond)
@@ -436,11 +436,11 @@ func TestManagerReconnectSubdomainChange(t *testing.T) {
 		collector := newMsgCollector()
 		mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
 
-		_ = mgr.Add(8080, "web", "")
+		_ = mgr.Add(8080, "web", "", "")
 
 		managed := mgr.getManagedTunnel(8080)
 		// Simulate initial connection: set subdomain
-		managed.Callbacks.OnConnected("old-sub", "https://old-sub.justtunnel.dev", "localhost:8080")
+		managed.Callbacks.OnConnected("old-sub", "https://old-sub.justtunnel.dev", "localhost:8080", false)
 
 		// Record some stats
 		managed.Stats.Record(RequestEntry{
@@ -483,10 +483,10 @@ func TestManagerReconnectSubdomainChange(t *testing.T) {
 		collector := newMsgCollector()
 		mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
 
-		_ = mgr.Add(8080, "web", "")
+		_ = mgr.Add(8080, "web", "", "")
 
 		managed := mgr.getManagedTunnel(8080)
-		managed.Callbacks.OnConnected("same-sub", "https://same-sub.justtunnel.dev", "localhost:8080")
+		managed.Callbacks.OnConnected("same-sub", "https://same-sub.justtunnel.dev", "localhost:8080", false)
 
 		managed.Stats.Record(RequestEntry{
 			Method:     "GET",
@@ -520,8 +520,8 @@ func TestManagerRemoveByIndexBounds(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mgr := NewTunnelManager(mockTunnelFactory(nil), nil)
-			_ = mgr.Add(8080, "web", "")
-			_ = mgr.Add(3000, "api", "")
+			_ = mgr.Add(8080, "web", "", "")
+			_ = mgr.Add(3000, "api", "", "")
 
 			err := mgr.RemoveByIndex(tt.index)
 			if err == nil {
@@ -541,7 +541,7 @@ func TestManagerRunErrorPropagation(t *testing.T) {
 		mocks := make(map[int]*mockTunnel)
 		mgr := NewTunnelManager(mockTunnelFactoryWithError(tunnelErr, mocks), collector)
 
-		err := mgr.Add(8080, "web", "")
+		err := mgr.Add(8080, "web", "", "")
 		if err != nil {
 			t.Fatalf("Add(8080) returned unexpected error: %v", err)
 		}
@@ -580,7 +580,7 @@ func TestManagerRunErrorPropagation(t *testing.T) {
 		mocks := make(map[int]*mockTunnel)
 		mgr := NewTunnelManager(mockTunnelFactory(mocks), collector)
 
-		err := mgr.Add(8080, "web", "")
+		err := mgr.Add(8080, "web", "", "")
 		if err != nil {
 			t.Fatalf("Add(8080) returned unexpected error: %v", err)
 		}
@@ -603,13 +603,79 @@ func TestManagerRunErrorPropagation(t *testing.T) {
 	})
 }
 
+func TestManagerCallbackPasswordProtected(t *testing.T) {
+	t.Run("connected callback with passwordProtected sets flag and sends it in message", func(t *testing.T) {
+		collector := newMsgCollector()
+		mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
+
+		_ = mgr.Add(8080, "web", "", "")
+
+		managed := mgr.getManagedTunnel(8080)
+		if managed == nil {
+			t.Fatal("expected managed tunnel for port 8080")
+		}
+
+		// Simulate connection with password protection enabled
+		managed.Callbacks.OnConnected("test-sub", "https://test-sub.justtunnel.dev", "localhost:8080", true)
+
+		// Verify ManagedTunnel.PasswordProtected is set
+		managed.mu.RLock()
+		pwProtected := managed.PasswordProtected
+		managed.mu.RUnlock()
+		if !pwProtected {
+			t.Error("expected PasswordProtected to be true on ManagedTunnel")
+		}
+
+		// Verify the TunnelConnectedMsg carries PasswordProtected
+		msgs := collector.Messages()
+		foundMsg := false
+		for _, msg := range msgs {
+			if connMsg, ok := msg.(TunnelConnectedMsg); ok {
+				if connMsg.Port == 8080 && connMsg.PasswordProtected {
+					foundMsg = true
+					break
+				}
+			}
+		}
+		if !foundMsg {
+			t.Error("expected TunnelConnectedMsg with PasswordProtected=true")
+		}
+	})
+
+	t.Run("connected callback without password protection leaves flag false", func(t *testing.T) {
+		collector := newMsgCollector()
+		mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
+
+		_ = mgr.Add(8080, "web", "", "")
+
+		managed := mgr.getManagedTunnel(8080)
+		managed.Callbacks.OnConnected("test-sub", "https://test-sub.justtunnel.dev", "localhost:8080", false)
+
+		managed.mu.RLock()
+		pwProtected := managed.PasswordProtected
+		managed.mu.RUnlock()
+		if pwProtected {
+			t.Error("expected PasswordProtected to be false")
+		}
+
+		msgs := collector.Messages()
+		for _, msg := range msgs {
+			if connMsg, ok := msg.(TunnelConnectedMsg); ok {
+				if connMsg.Port == 8080 && connMsg.PasswordProtected {
+					t.Error("expected TunnelConnectedMsg with PasswordProtected=false")
+				}
+			}
+		}
+	})
+}
+
 func TestManagedTunnelConcurrentAccess(t *testing.T) {
 	// This test verifies that concurrent reads and writes to ManagedTunnel
 	// fields don't race. Run with -race to detect data races.
 	collector := newMsgCollector()
 	mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
 
-	_ = mgr.Add(8080, "web", "")
+	_ = mgr.Add(8080, "web", "", "")
 
 	managed := mgr.getManagedTunnel(8080)
 	if managed == nil {
@@ -622,7 +688,7 @@ func TestManagedTunnelConcurrentAccess(t *testing.T) {
 	go func() {
 		defer writeWg.Done()
 		for iter := 0; iter < 100; iter++ {
-			managed.Callbacks.OnConnected("sub", "https://sub.example.com", "localhost:8080")
+			managed.Callbacks.OnConnected("sub", "https://sub.example.com", "localhost:8080", false)
 		}
 	}()
 	go func() {

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -7,9 +7,10 @@ type TickMsg time.Time
 
 // TunnelConnectedMsg indicates a tunnel has successfully connected.
 type TunnelConnectedMsg struct {
-	Port      int
-	Subdomain string
-	PublicURL string
+	Port              int
+	Subdomain         string
+	PublicURL         string
+	PasswordProtected bool
 }
 
 // TunnelDisconnectedMsg indicates a tunnel has lost its connection.
@@ -64,4 +65,5 @@ type TunnelPreset struct {
 	Port      int    `yaml:"port"`
 	Name      string `yaml:"name,omitempty"`
 	Subdomain string `yaml:"subdomain,omitempty"`
+	Password  string `yaml:"password,omitempty"`
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -19,17 +19,18 @@ const (
 // TunnelDisplayEntry holds the display data for a single tunnel in the TUI.
 // This is a view-layer struct — no real tunnel connections, just display state.
 type TunnelDisplayEntry struct {
-	ID          int
-	Name        string
-	Port        int
-	Subdomain   string
-	PublicURL   string
-	State       TunnelState
-	Error       string
-	ConnectedAt time.Time
-	Requests    int64
-	AvgReqSec   float64
-	RecentRequests []RequestEntry
+	ID                int
+	Name              string
+	Port              int
+	Subdomain         string
+	PublicURL         string
+	State             TunnelState
+	Error             string
+	ConnectedAt       time.Time
+	Requests          int64
+	AvgReqSec         float64
+	PasswordProtected bool
+	RecentRequests    []RequestEntry
 }
 
 // PlanInfo holds the user's plan name and tunnel limit.
@@ -252,7 +253,7 @@ func (m Model) handleAddCommand(cmd AddCommand) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	addErr := m.manager.Add(cmd.Port, cmd.Name, cmd.Subdomain)
+	addErr := m.manager.Add(cmd.Port, cmd.Name, cmd.Subdomain, cmd.Password)
 	if addErr != nil {
 		m.errorMessage = addErr.Error()
 		return m, nil
@@ -328,6 +329,7 @@ func (m Model) handleTunnelConnected(msg TunnelConnectedMsg) (tea.Model, tea.Cmd
 			m.tunnels[idx].Subdomain = msg.Subdomain
 			m.tunnels[idx].PublicURL = msg.PublicURL
 			m.tunnels[idx].ConnectedAt = time.Now()
+			m.tunnels[idx].PasswordProtected = msg.PasswordProtected
 			break
 		}
 	}
@@ -430,7 +432,7 @@ func (m Model) handleConfigChanged(msg ConfigChangedMsg) (tea.Model, tea.Cmd) {
 
 	// Add tunnels that are new in the config
 	for _, preset := range msg.ToAdd {
-		addErr := m.manager.Add(preset.Port, preset.Name, preset.Subdomain)
+		addErr := m.manager.Add(preset.Port, preset.Name, preset.Subdomain, preset.Password)
 		if addErr != nil {
 			continue
 		}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -875,6 +875,79 @@ func TestCtrlCWithManagerCallsShutdown(t *testing.T) {
 	}
 }
 
+func TestPasswordProtectedDisplayEntry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("TunnelConnectedMsg with PasswordProtected sets display entry flag", func(t *testing.T) {
+		t.Parallel()
+		model, _ := newManagedTestModel(t)
+
+		// Add a tunnel
+		model = typeCommand(t, model, "/add 8080")
+		model, _ = pressEnter(t, model)
+
+		if len(model.tunnels) != 1 {
+			t.Fatalf("expected 1 tunnel, got %d", len(model.tunnels))
+		}
+
+		// Simulate connected message with password protection
+		connMsg := TunnelConnectedMsg{
+			Port:              8080,
+			Subdomain:         "my-sub",
+			PublicURL:         "https://my-sub.justtunnel.dev",
+			PasswordProtected: true,
+		}
+		updatedModel, _ := model.Update(connMsg)
+		model = updatedModel.(Model)
+
+		if !model.tunnels[0].PasswordProtected {
+			t.Error("expected PasswordProtected to be true in display entry")
+		}
+	})
+
+	t.Run("TunnelConnectedMsg without PasswordProtected leaves display entry false", func(t *testing.T) {
+		t.Parallel()
+		model, _ := newManagedTestModel(t)
+
+		model = typeCommand(t, model, "/add 8080")
+		model, _ = pressEnter(t, model)
+
+		connMsg := TunnelConnectedMsg{
+			Port:              8080,
+			Subdomain:         "my-sub",
+			PublicURL:         "https://my-sub.justtunnel.dev",
+			PasswordProtected: false,
+		}
+		updatedModel, _ := model.Update(connMsg)
+		model = updatedModel.(Model)
+
+		if model.tunnels[0].PasswordProtected {
+			t.Error("expected PasswordProtected to be false in display entry")
+		}
+	})
+}
+
+func TestAddCommandWithPassword(t *testing.T) {
+	t.Parallel()
+
+	t.Run("add command with --password passes password to manager", func(t *testing.T) {
+		t.Parallel()
+		model, _ := newManagedTestModel(t)
+		model = typeCommand(t, model, "/add 8080 --password secret123")
+		model, _ = pressEnter(t, model)
+
+		if model.errorMessage != "" {
+			t.Errorf("unexpected error: %s", model.errorMessage)
+		}
+		if len(model.tunnels) != 1 {
+			t.Fatalf("expected 1 tunnel, got %d", len(model.tunnels))
+		}
+		if model.tunnels[0].Port != 8080 {
+			t.Errorf("tunnel port = %d, want 8080", model.tunnels[0].Port)
+		}
+	})
+}
+
 func TestNewModelWithManagerInitialState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -61,7 +61,11 @@ func renderListView(model Model) string {
 				marker = styleSelected.Render("> ")
 			}
 
-			styledStatus := stateStyle(entry.State).Render(fmt.Sprintf("%-15s", stateLabel(entry.State)))
+			statusText := stateLabel(entry.State)
+			if entry.PasswordProtected {
+				statusText += " [P]"
+			}
+			styledStatus := stateStyle(entry.State).Render(fmt.Sprintf("%-15s", statusText))
 
 			row := fmt.Sprintf("%-3d %-15s %s "+urlFmt+" %-10s %-6d",
 				entry.ID,
@@ -124,10 +128,16 @@ func renderDetailView(model Model) string {
 		styleDetailLabel.Render("Subdomain:"),
 		entry.Subdomain))
 
-	statusText := stateStyle(entry.State).Render(stateLabel(entry.State))
+	detailStatusText := stateStyle(entry.State).Render(stateLabel(entry.State))
 	builder.WriteString(fmt.Sprintf("  %s  %s\n",
 		styleDetailLabel.Render("Status:"),
-		statusText))
+		detailStatusText))
+
+	if entry.PasswordProtected {
+		builder.WriteString(fmt.Sprintf("  %s  %s\n",
+			styleDetailLabel.Render("Protected:"),
+			stateStyle(StateConnected).Render("Yes")))
+	}
 
 	if entry.Error != "" {
 		builder.WriteString(fmt.Sprintf("  %s  %s\n",

--- a/internal/tui/views_test.go
+++ b/internal/tui/views_test.go
@@ -376,6 +376,110 @@ func TestTruncateString(t *testing.T) {
 	}
 }
 
+func TestRenderListViewPasswordProtectedIndicator(t *testing.T) {
+	t.Parallel()
+
+	tunnels := []TunnelDisplayEntry{
+		{
+			ID:                1,
+			Name:              "api",
+			Port:              3000,
+			PublicURL:         "https://api.justtunnel.dev",
+			State:             StateConnected,
+			PasswordProtected: true,
+			Requests:          10,
+		},
+		{
+			ID:        2,
+			Name:      "web",
+			Port:      8080,
+			PublicURL: "https://web.justtunnel.dev",
+			State:     StateConnected,
+			Requests:  5,
+		},
+	}
+
+	model := NewModel(tunnels, PlanInfo{Name: "Pro", MaxTunnels: 5})
+	model.width = 120
+	model.height = 24
+	output := renderListView(model)
+
+	// The password-protected tunnel should show [P] in its row
+	lines := strings.Split(output, "\n")
+	foundProtectedIndicator := false
+	for _, line := range lines {
+		if strings.Contains(line, "3000") && strings.Contains(line, "[P]") {
+			foundProtectedIndicator = true
+		}
+	}
+	if !foundProtectedIndicator {
+		t.Error("list view should show [P] indicator for password-protected tunnel on port 3000")
+	}
+
+	// The non-protected tunnel should NOT show [P]
+	for _, line := range lines {
+		if strings.Contains(line, "8080") && strings.Contains(line, "[P]") {
+			t.Error("list view should NOT show [P] indicator for non-protected tunnel on port 8080")
+		}
+	}
+}
+
+func TestRenderDetailViewPasswordProtected(t *testing.T) {
+	t.Parallel()
+
+	tunnels := []TunnelDisplayEntry{
+		{
+			ID:                1,
+			Name:              "api",
+			Port:              3000,
+			Subdomain:         "api-sub",
+			PublicURL:         "https://api-sub.justtunnel.dev",
+			State:             StateConnected,
+			PasswordProtected: true,
+			Requests:          10,
+		},
+	}
+
+	model := NewModel(tunnels, PlanInfo{Name: "Pro", MaxTunnels: 5})
+	model.viewState = viewDetail
+	model.selectedIndex = 0
+
+	output := renderDetailView(model)
+
+	if !strings.Contains(output, "Protected:") {
+		t.Error("detail view should show 'Protected:' label for password-protected tunnel")
+	}
+	if !strings.Contains(output, "Yes") {
+		t.Error("detail view should show 'Yes' for password-protected tunnel")
+	}
+}
+
+func TestRenderDetailViewNotPasswordProtected(t *testing.T) {
+	t.Parallel()
+
+	tunnels := []TunnelDisplayEntry{
+		{
+			ID:        1,
+			Name:      "api",
+			Port:      3000,
+			Subdomain: "api-sub",
+			PublicURL: "https://api-sub.justtunnel.dev",
+			State:     StateConnected,
+			Requests:  10,
+		},
+	}
+
+	model := NewModel(tunnels, PlanInfo{Name: "Pro", MaxTunnels: 5})
+	model.viewState = viewDetail
+	model.selectedIndex = 0
+
+	output := renderDetailView(model)
+
+	if strings.Contains(output, "Protected:") {
+		t.Error("detail view should NOT show 'Protected:' label for non-protected tunnel")
+	}
+}
+
 func TestRenderListViewCombinedNarrowAndShort(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/watcher_test.go
+++ b/internal/tui/watcher_test.go
@@ -282,7 +282,7 @@ func TestModelHandlesConfigChangedMsg(t *testing.T) {
 		model := NewModelWithManager(mgr, PlanInfo{Name: "Pro", MaxTunnels: 5})
 
 		// Pre-add a tunnel that will be removed
-		addErr := mgr.Add(3000, "frontend", "")
+		addErr := mgr.Add(3000, "frontend", "", "")
 		if addErr != nil {
 			t.Fatalf("Add(3000) failed: %v", addErr)
 		}
@@ -318,7 +318,7 @@ func TestModelHandlesConfigChangedMsg(t *testing.T) {
 		mgr := NewTunnelManager(mockTunnelFactory(mocks), collector)
 		model := NewModelWithManager(mgr, PlanInfo{Name: "Pro", MaxTunnels: 5})
 
-		addErr := mgr.Add(3000, "frontend", "")
+		addErr := mgr.Add(3000, "frontend", "", "")
 		if addErr != nil {
 			t.Fatalf("Add(3000) failed: %v", addErr)
 		}
@@ -393,7 +393,7 @@ func TestConfigWatcher_DiffComputedCorrectly(t *testing.T) {
 	mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
 
 	// Add port 3000 to manager so it's already running
-	addErr := mgr.Add(3000, "frontend", "")
+	addErr := mgr.Add(3000, "frontend", "", "")
 	if addErr != nil {
 		t.Fatalf("failed to add initial tunnel: %v", addErr)
 	}

--- a/internal/tunnel/frames.go
+++ b/internal/tunnel/frames.go
@@ -6,11 +6,12 @@ import (
 )
 
 type TunnelAssigned struct {
-	Type           string `json:"type"`
-	TunnelID       string `json:"tunnel_id"`
-	Subdomain      string `json:"subdomain"`
-	URL            string `json:"url"`
-	ReconnectToken string `json:"reconnect_token,omitempty"`
+	Type              string `json:"type"`
+	TunnelID          string `json:"tunnel_id"`
+	Subdomain         string `json:"subdomain"`
+	URL               string `json:"url"`
+	ReconnectToken    string `json:"reconnect_token,omitempty"`
+	PasswordProtected bool   `json:"password_protected,omitempty"`
 }
 
 type RequestFrame struct {

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -28,7 +28,7 @@ type ReconnectInfo struct {
 
 type Callbacks struct {
 	OnConnecting    func()
-	OnConnected     func(subdomain, url, localTarget string)
+	OnConnected     func(subdomain, url, localTarget string, passwordProtected bool)
 	OnRequest       func(method, path string, status int, latency time.Duration)
 	OnReconnecting  func(attempt int, backoff time.Duration)
 	OnReconnectWait func(attempt int, remaining time.Duration)
@@ -51,6 +51,9 @@ type Tunnel struct {
 	tunnelURL      string
 	tunnelID       string
 	reconnectToken string
+
+	password          string
+	passwordProtected bool // set from tunnel_assigned frame
 
 	maxReconnectAttempts int
 	reconnecting         bool
@@ -75,6 +78,18 @@ func (t *Tunnel) SetMaxReconnectAttempts(maxAttempts int) {
 		maxAttempts = 0
 	}
 	t.maxReconnectAttempts = maxAttempts
+}
+
+// SetPassword sets the password that will be sent as an X-Tunnel-Password header
+// when connecting to the server.
+func (t *Tunnel) SetPassword(pw string) {
+	t.password = pw
+}
+
+// PasswordProtected returns true if the server confirmed that the tunnel is
+// password-protected (from the tunnel_assigned frame).
+func (t *Tunnel) PasswordProtected() bool {
+	return t.passwordProtected
 }
 
 // Run is the main lifecycle: connect, read loop, reconnect on failure.
@@ -117,6 +132,12 @@ func (t *Tunnel) connectWithURL(ctx context.Context, dialURL string) error {
 			"Authorization": []string{"Bearer " + t.authToken},
 		}
 	}
+	if t.password != "" {
+		if opts.HTTPHeader == nil {
+			opts.HTTPHeader = http.Header{}
+		}
+		opts.HTTPHeader.Set("X-Tunnel-Password", t.password)
+	}
 
 	conn, httpResp, err := websocket.Dial(ctx, dialURL, opts)
 	if err != nil {
@@ -157,10 +178,11 @@ func (t *Tunnel) connectWithURL(ctx context.Context, dialURL string) error {
 	t.tunnelURL = assigned.URL
 	t.tunnelID = assigned.TunnelID
 	t.reconnectToken = assigned.ReconnectToken
+	t.passwordProtected = assigned.PasswordProtected
 
 	// Only fire OnConnected for the initial connection, not during reconnects.
 	if !t.reconnecting && t.callbacks.OnConnected != nil {
-		t.callbacks.OnConnected(assigned.Subdomain, assigned.URL, t.localTarget)
+		t.callbacks.OnConnected(assigned.Subdomain, assigned.URL, t.localTarget, t.passwordProtected)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Add `--password` CLI flag to password-protect tunnels (4-128 chars)
- Add `password:` field to YAML tunnel config for multi-tunnel setups
- Send `X-Tunnel-Password` header on WebSocket dial and reconnect
- Show `[P]` lock indicator in TUI list view for protected tunnels
- Show "Protected: Yes" in TUI detail view
- Add `--password` flag to `/add` slash command
- Parse `password_protected` from `tunnel_assigned` server frame

## Test plan

- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (335 tests across 8 packages)
- [x] `justtunnel 3000 --password test` sends X-Tunnel-Password header
- [x] `--password ab` rejected (too short)
- [x] YAML config with `password: mysecret` parsed correctly
- [x] TUI shows `[P]` next to status when server confirms password_protected
- [x] `/add 8080 --password secret` works in TUI
- [x] Reconnection re-sends password header automatically
