### PR TITLE
local-target timeout and reconnect token v2

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ var (
 	password             string
 	maxReconnectAttempts int
 	tunnelConfigFile     string
+	localTimeout         time.Duration
 )
 
 var rootCmd = &cobra.Command{
@@ -49,6 +50,7 @@ func init() {
 	rootCmd.Flags().IntVar(&maxReconnectAttempts, "max-reconnect-attempts", 50, "maximum number of reconnection attempts (0 = unlimited)")
 	rootCmd.Flags().StringVar(&tunnelConfigFile, "config-file", "", "YAML config file with tunnel definitions")
 	rootCmd.Flags().StringVar(&password, "password", "", "password-protect the tunnel (4-128 chars)")
+	rootCmd.Flags().DurationVar(&localTimeout, "local-timeout", tunnel.DefaultLocalTimeout, "per-request timeout when proxying to the local target (e.g. 30s, 1m)")
 	rootCmd.SilenceErrors = true
 	rootCmd.SilenceUsage = true
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
@@ -296,6 +298,10 @@ func newTunnelFactory(serverURL, authToken string, logger *slog.Logger, cmd *cob
 			tun.SetMaxReconnectAttempts(maxReconnectAttempts)
 		}
 
+		if cmd.Flags().Changed("local-timeout") {
+			tun.SetLocalTimeout(localTimeout)
+		}
+
 		return tun
 	}
 }
@@ -372,6 +378,10 @@ func runNonTTY(port int, cfg *config.Config, serverURL string, logger *slog.Logg
 		tun.SetMaxReconnectAttempts(maxReconnectAttempts)
 	} else if cfg.MaxReconnectAttempts != nil {
 		tun.SetMaxReconnectAttempts(*cfg.MaxReconnectAttempts)
+	}
+
+	if cmd.Flags().Changed("local-timeout") {
+		tun.SetLocalTimeout(localTimeout)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/tunnel/frames.go
+++ b/internal/tunnel/frames.go
@@ -11,6 +11,7 @@ type TunnelAssigned struct {
 	Subdomain         string `json:"subdomain"`
 	URL               string `json:"url"`
 	ReconnectToken    string `json:"reconnect_token,omitempty"`
+	ReconnectIssuedAt int64  `json:"reconnect_issued_at,omitempty"`
 	PasswordProtected bool   `json:"password_protected,omitempty"`
 }
 

--- a/internal/tunnel/proxy.go
+++ b/internal/tunnel/proxy.go
@@ -17,9 +17,14 @@ import (
 
 const maxBodySize = 10 << 20 // 10 MB
 
+// DefaultLocalTimeout is the per-request timeout when proxying to the local
+// target. Was 120s; trimmed to 30s so a slow/dead local target doesn't pin
+// goroutines + memory on the server side for two whole minutes per request.
+const DefaultLocalTimeout = 30 * time.Second
+
 // ProxyRequest forwards a RequestFrame to the local target server and returns
-// the corresponding ResponseFrame.
-func ProxyRequest(ctx context.Context, frame RequestFrame, target string, logger *slog.Logger) (ResponseFrame, error) {
+// the corresponding ResponseFrame. Pass timeout=0 for the package default.
+func ProxyRequest(ctx context.Context, frame RequestFrame, target string, timeout time.Duration, logger *slog.Logger) (ResponseFrame, error) {
 	var bodyReader io.Reader
 	var bodyBytes []byte
 	if frame.Body != "" {
@@ -48,7 +53,10 @@ func ProxyRequest(ctx context.Context, frame RequestFrame, target string, logger
 		display.LogRequestDetail("Request", frame.Headers, bodyBytes)
 	}
 
-	client := &http.Client{Timeout: 120 * time.Second}
+	if timeout <= 0 {
+		timeout = DefaultLocalTimeout
+	}
+	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req)
 	if err != nil {
 		if errors.Is(err, syscall.ECONNREFUSED) {

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strconv"
 	"sync"
 	"time"
 
@@ -37,20 +38,22 @@ type Callbacks struct {
 }
 
 type Tunnel struct {
-	serverURL   string
-	localTarget string
-	authToken   string
-	logger      *slog.Logger
-	callbacks   Callbacks
+	serverURL    string
+	localTarget  string
+	localTimeout time.Duration
+	authToken    string
+	logger       *slog.Logger
+	callbacks    Callbacks
 
 	conn   *websocket.Conn
 	connMu sync.Mutex // protects conn field and WebSocket writes
 	wg     sync.WaitGroup
 
-	subdomain      string
-	tunnelURL      string
-	tunnelID       string
-	reconnectToken string
+	subdomain         string
+	tunnelURL         string
+	tunnelID          string
+	reconnectToken    string
+	reconnectIssuedAt int64
 
 	password          string
 	passwordProtected bool // set from tunnel_assigned frame
@@ -78,6 +81,15 @@ func (t *Tunnel) SetMaxReconnectAttempts(maxAttempts int) {
 		maxAttempts = 0
 	}
 	t.maxReconnectAttempts = maxAttempts
+}
+
+// SetLocalTimeout sets the per-request timeout for proxying to the local
+// target. Pass 0 to use DefaultLocalTimeout.
+func (t *Tunnel) SetLocalTimeout(timeout time.Duration) {
+	if timeout < 0 {
+		timeout = 0
+	}
+	t.localTimeout = timeout
 }
 
 // SetPassword sets the password that will be sent as an X-Tunnel-Password header
@@ -178,6 +190,7 @@ func (t *Tunnel) connectWithURL(ctx context.Context, dialURL string) error {
 	t.tunnelURL = assigned.URL
 	t.tunnelID = assigned.TunnelID
 	t.reconnectToken = assigned.ReconnectToken
+	t.reconnectIssuedAt = assigned.ReconnectIssuedAt
 	t.passwordProtected = assigned.PasswordProtected
 
 	// Only fire OnConnected for the initial connection, not during reconnects.
@@ -226,7 +239,7 @@ func (t *Tunnel) handleRequest(ctx context.Context, frame *RequestFrame) {
 	t.connMu.Unlock()
 
 	start := time.Now()
-	resp, err := ProxyRequest(ctx, *frame, t.localTarget, t.logger)
+	resp, err := ProxyRequest(ctx, *frame, t.localTarget, t.localTimeout, t.logger)
 	latency := time.Since(start)
 
 	if err != nil {
@@ -293,6 +306,9 @@ func (t *Tunnel) buildReconnectURL() string {
 	query.Set("subdomain", t.subdomain)
 	query.Set("tunnel_id", t.tunnelID)
 	query.Set("reconnect_token", t.reconnectToken)
+	if t.reconnectIssuedAt > 0 {
+		query.Set("reconnect_issued_at", strconv.FormatInt(t.reconnectIssuedAt, 10))
+	}
 	parsed.RawQuery = query.Encode()
 	return parsed.String()
 }


### PR DESCRIPTION
## Summary

Companion to the server's production hardening pass. Two CLI changes:

1. **`--local-timeout` flag** (default 30s, was hard-coded 120s). When the local target is slow or dead, every request used to hang the server-side proxy for 2 minutes — that pinned a goroutine + memory per request. 30s is more than enough for legit local apps and fails fast when localhost is down.

2. **Reconnect token v2** — adds `reconnect_issued_at` to the `tunnel_assigned` frame and echoes it on reconnect URLs. This pairs with the server-side change in justtunnel/justtunnel-server#6, which expires reconnect tokens after 24h. Old CLIs without this field continue to work via the server's legacy validation path.

## Files

- `cmd/root.go` — `--local-timeout` flag wired to `tunnel.SetLocalTimeout`
- `internal/tunnel/proxy.go` — accepts a `timeout time.Duration`; new `DefaultLocalTimeout` constant
- `internal/tunnel/tunnel.go` — `localTimeout` field, setter, threads through to `ProxyRequest`; sends `reconnect_issued_at` query param on reconnect
- `internal/tunnel/frames.go` — `ReconnectIssuedAt` field on `TunnelAssigned`

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test -race ./...` — 335 tests pass
- [x] manual: start a slow local target (sleep 60s), confirm CLI returns 502 after 30s instead of hanging 2 min
- [x] manual: kill WS, confirm CLI reconnects with the same subdomain (reconnect-token round-trips correctly)
