### PR TITLE
add --version flag and surface version in --help

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/justtunnel/justtunnel-cli/internal/display"
 	"github.com/justtunnel/justtunnel-cli/internal/tui"
 	"github.com/justtunnel/justtunnel-cli/internal/tunnel"
+	"github.com/justtunnel/justtunnel-cli/internal/version"
 )
 
 var (
@@ -39,8 +40,8 @@ var rootCmd = &cobra.Command{
 	Use:   "justtunnel [port]",
 	Short: "Expose a local HTTP server to the internet",
 	Long:  "justtunnel creates a public URL that tunnels traffic to a local port via a persistent WebSocket connection.",
-	Args: cobra.RangeArgs(0, 1),
-	RunE: runTunnel,
+	Args:  cobra.RangeArgs(0, 1),
+	RunE:  runTunnel,
 }
 
 func init() {
@@ -54,6 +55,18 @@ func init() {
 	rootCmd.SilenceErrors = true
 	rootCmd.SilenceUsage = true
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
+	// Wire `--version` flag and a custom template that matches the
+	// existing `justtunnel version` subcommand format (3 lines).
+	rootCmd.Version = version.Version
+	rootCmd.SetVersionTemplate("justtunnel " + version.Version +
+		"\n  commit: " + version.Commit +
+		"\n  built:  " + version.Date + "\n")
+
+	// Surface the version in `--help` output by appending it to the long
+	// description. Cobra's default help template prints Long verbatim, so
+	// this puts the version near the top of the output.
+	rootCmd.Long = rootCmd.Long + "\n\nVersion: " + version.Version
 }
 
 func Execute() error {

--- a/cmd/root_version_test.go
+++ b/cmd/root_version_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/justtunnel/justtunnel-cli/internal/version"
+)
+
+// TestRootCmd_VersionFlag_PrintsVersion verifies that the top-level --version
+// flag prints the same three-line format produced by `justtunnel version`.
+// This is wired by setting rootCmd.Version and overriding the version template
+// via rootCmd.SetVersionTemplate.
+func TestRootCmd_VersionFlag_PrintsVersion(t *testing.T) {
+	buf := &bytes.Buffer{}
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"--version"})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute with --version returned error: %v", err)
+	}
+
+	output := buf.String()
+
+	expected := "justtunnel " + version.Version + "\n" +
+		"  commit: " + version.Commit + "\n" +
+		"  built:  " + version.Date + "\n"
+
+	if output != expected {
+		t.Errorf("--version output mismatch\nwant: %q\ngot:  %q", expected, output)
+	}
+}
+
+// TestRootCmd_HelpOutput_IncludesVersion verifies that running --help shows
+// the version somewhere in the output (cobra prepends a Version line when
+// rootCmd.Version is set).
+func TestRootCmd_HelpOutput_IncludesVersion(t *testing.T) {
+	buf := &bytes.Buffer{}
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"--help"})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute with --help returned error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, version.Version) {
+		t.Errorf("expected --help output to contain version %q somewhere, got %q", version.Version, output)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a top-level `--version` flag and surfaces the current version in the `--help` output. The existing `justtunnel version` subcommand is untouched — `--version` produces the same 3-line `version / commit / built` format.

## Changes

- `cmd/root.go` — set `rootCmd.Version = version.Version`, override `SetVersionTemplate` to match the subcommand format, append a `Version: <ver>` line to `rootCmd.Long` so the version is visible in `--help`
- `cmd/root_version_test.go` — exact-output equality test for `--version`, plus a `--help` smoke test that asserts the version is in the rendered output

## Verification

```
$ justtunnel --version
justtunnel dev
  commit: unknown
  built:  unknown
```

(`dev` / `unknown` are the unset-ldflag defaults; in a real build the values come from `-X` ldflags.)

- `go vet ./...` — clean
- `go test -race -count=1 ./...` — **337 passed in 8 packages** (baseline 335 → +2 tests)

## Test plan

- [ ] `justtunnel --version` prints 3 lines matching the `version` subcommand
- [ ] `justtunnel --help` shows the version somewhere in the output
- [ ] `justtunnel version` (subcommand) still works
- [ ] Released binary picks up correct version via release-workflow ldflags

Closes #24.
