### PR TITLE
pre-commit safety hook (.githooks/pre-commit)

### DIFF
--- a/.githooks/install.sh
+++ b/.githooks/install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Wire up tracked git hooks for this clone.
+# Run once after cloning: ./.githooks/install.sh
+set -euo pipefail
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-commit
+echo "git hooks installed (core.hooksPath = .githooks)"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Pre-commit safety check.
+# Blocks accidental commits of DB dumps, raw secrets, and oversized blobs.
+# Runs against the staged set (git diff --cached --diff-filter=A).
+# Bypass with `git commit --no-verify` only when you understand the risk.
+
+set -euo pipefail
+
+added=$(git diff --cached --name-only --diff-filter=A)
+[[ -z "$added" ]] && exit 0
+
+fail() {
+    printf '\n\033[31mpre-commit reject:\033[0m %s\n' "$1" >&2
+    printf 'See .githooks/pre-commit. Bypass with --no-verify if intentional.\n\n' >&2
+    exit 1
+}
+
+# 1. Known-bad paths (DB dump dirs, vendor leaks, etc.)
+if echo "$added" | grep -qE '(^|/)(jt-backup|mongodump|dbdump|dump|backup)/'; then
+    fail "DB-dump-style path in commit. Should be gitignored."
+fi
+
+# 2. Known-bad extensions (raw DB / dump files)
+if echo "$added" | grep -qE '\.(bson|dump|sqlite3?|pgdump|mysqldump)$'; then
+    fail "Raw DB file in commit. Use a fixture or seed script."
+fi
+
+# 3. Secret-bearing filenames (defense in depth — .env should be gitignored)
+if echo "$added" | grep -E '(^|/)\.env($|\..+$)' | grep -vE '\.env\.example$' | grep -q .; then
+    fail ".env file in commit. Should be gitignored."
+fi
+if echo "$added" | grep -qE '(credentials|service-account|secret)\.json$'; then
+    fail "Likely-credentials file in commit. Verify or rename."
+fi
+
+# 4. Size guard — anything > 1 MB demands explicit confirmation
+limit=$((1024 * 1024))
+while IFS= read -r path; do
+    [[ -z "$path" ]] && continue
+    size=$(git cat-file -s ":$path" 2>/dev/null || echo 0)
+    if (( size > limit )); then
+        fail "$path is $((size/1024)) KB (limit 1024 KB). Confirm intent or use Git LFS."
+    fi
+done <<< "$added"
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ coverage.out
 *.dll
 *.so
 *.dylib
+
+# Local mongodump output — never commit DB snapshots
+jt-backup/


### PR DESCRIPTION
## What's Changing

Adds a tracked pre-commit safety hook at `.githooks/pre-commit` plus a one-time installer at `.githooks/install.sh`. The hook runs against staged files and rejects commits that match any of:

1. **Known-bad paths** — `jt-backup/`, `mongodump/`, `dbdump/`, `dump/`, `backup/` (DB-snapshot directory names)
2. **Known-bad extensions** — `*.bson`, `*.dump`, `*.sqlite`, `*.sqlite3`, `*.pgdump`, `*.mysqldump`
3. **Secret-bearing filenames** — `.env*` (except `.env.example`), `credentials.json`, `service-account.json`, `*secret.json`
4. **Size guard** — any single file > 1 MB rejects with a Git-LFS suggestion

Bypass with `git commit --no-verify` only when intentional.

## Why

A recent commit accidentally swept a local `mongodump` directory (`jt-backup/`) into a feature-branch commit and pushed it to a draft PR before it was caught. `.gitignore` is the primary defense; this hook is defense in depth — catches the things gitignore missed.

## Setup

`.git/hooks/` is per-clone and not tracked. We use the `core.hooksPath = .githooks` pattern instead, which makes the hook tracked (PR-reviewable) and installed by a one-line setup:

```bash
./.githooks/install.sh
```

Run once after cloning. Idempotent.

## Validation

- [x] Hook is `set -euo pipefail` and tested to reject each of the four guard categories
- [x] No-op fast path when no files are staged-as-added
- [x] Bypass via `--no-verify` works (intentional escape hatch)
- [x] `.gitignore` updated with `jt-backup/` (defense in depth — gitignore is still primary)
