### PR TITLE
sync active context to server on context use (#44)

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -33,6 +35,15 @@ type membershipFetcher func(client *http.Client, baseURL, authToken string) ([]m
 
 // fetchMemberships is the package-level fetcher; tests may swap it.
 var fetchMemberships membershipFetcher = fetchMembershipsHTTP
+
+// activeContextPusher syncs the user's active context to the server so the
+// WS worker handshake can resolve the team without requiring team_slug on
+// every dial. Production wiring uses pushActiveContextHTTP; tests inject
+// stubs.
+type activeContextPusher func(client *http.Client, baseURL, authToken, contextName string) error
+
+// pushActiveContext is the package-level pusher; tests may swap it.
+var pushActiveContext activeContextPusher = pushActiveContextHTTP
 
 var contextCmd = &cobra.Command{
 	Use:   "context",
@@ -175,6 +186,21 @@ func runContextUse(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Active context set to %s.\n", name)
+
+	// Best-effort sync to the server so the WS worker handshake can resolve
+	// the team without team_slug on the dial URL. Local config remains the
+	// source of truth — push failures degrade to a stderr warning so the
+	// user can keep working offline. See justtunnel-cli#44.
+	if cfg.AuthToken != "" {
+		baseURL, parseErr := apiBaseURL(cfg.ServerURL)
+		if parseErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not sync context to server: %v\n", parseErr)
+			return nil
+		}
+		if pushErr := pushActiveContext(nil, baseURL, cfg.AuthToken, name); pushErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not sync context to server: %v\n", pushErr)
+		}
+	}
 	return nil
 }
 
@@ -224,4 +250,62 @@ func fetchMembershipsHTTP(client *http.Client, baseURL, authToken string) ([]mem
 		return nil, true, fmt.Errorf("decode response: %w", err)
 	}
 	return payload.Memberships, true, nil
+}
+
+// pushActiveContextHTTP POSTs the active context name to the server so the
+// user.active_context column reflects the CLI's local choice. The endpoint
+// is /api/me/preferences/active-context with body
+// {"kind":"personal"|"team","slug":"<slug>"}. Empty input is rejected here
+// (caller validates first via config.ValidateContext).
+func pushActiveContextHTTP(client *http.Client, baseURL, authToken, contextName string) error {
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+
+	var body struct {
+		Kind string `json:"kind"`
+		Slug string `json:"slug,omitempty"`
+	}
+	switch {
+	case contextName == config.PersonalContext:
+		body.Kind = "personal"
+	case strings.HasPrefix(contextName, config.TeamContextPrefix):
+		body.Kind = "team"
+		body.Slug = strings.TrimPrefix(contextName, config.TeamContextPrefix)
+		if body.Slug == "" {
+			return fmt.Errorf("team context missing slug")
+		}
+	default:
+		return fmt.Errorf("unknown context shape: %s", contextName)
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("encode body: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/api/me/preferences/active-context", bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", config.AuthHeaderPrefix+authToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// 404 from older servers without the route is treated as a soft failure
+	// so the CLI doesn't surface a confusing warning every time someone
+	// runs against a not-yet-upgraded server.
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		errorBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("server returned %d: %s", resp.StatusCode, strings.TrimSpace(string(errorBody)))
+	}
+	return nil
 }

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -134,6 +135,130 @@ func TestContextFlagRejectsInvalid(t *testing.T) {
 	_, err := runCmd(t, "--context", "garbage", "context", "show")
 	if err == nil {
 		t.Fatal("expected error for --context garbage, got nil")
+	}
+}
+
+// TestContextUsePushesToServer verifies that `context use team:<slug>` calls
+// the active-context sync endpoint with the right body when an auth token
+// is present. Regression guard for justtunnel-cli#44.
+func TestContextUsePushesToServer(t *testing.T) {
+	resetContextState(t, &config.Config{
+		ServerURL: "wss://api.example.com/ws",
+		AuthToken: "tok_test",
+	})
+
+	previousPusher := pushActiveContext
+	t.Cleanup(func() { pushActiveContext = previousPusher })
+
+	var got struct {
+		called      bool
+		baseURL     string
+		authToken   string
+		contextName string
+	}
+	pushActiveContext = func(client *http.Client, baseURL, authToken, contextName string) error {
+		got.called = true
+		got.baseURL = baseURL
+		got.authToken = authToken
+		got.contextName = contextName
+		return nil
+	}
+
+	if _, err := runCmd(t, "context", "use", "team:acme"); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	if !got.called {
+		t.Fatal("pushActiveContext was not called")
+	}
+	if got.contextName != "team:acme" {
+		t.Errorf("contextName: got %q want %q", got.contextName, "team:acme")
+	}
+	if got.authToken != "tok_test" {
+		t.Errorf("authToken: got %q want %q", got.authToken, "tok_test")
+	}
+	if !strings.HasPrefix(got.baseURL, "https://") {
+		t.Errorf("baseURL should be https-derived: got %q", got.baseURL)
+	}
+}
+
+// TestContextUseSkipsServerSyncWhenLoggedOut verifies that the push is a
+// no-op when no auth token is present — the user can still configure the
+// CLI offline.
+func TestContextUseSkipsServerSyncWhenLoggedOut(t *testing.T) {
+	resetContextState(t, &config.Config{ServerURL: "wss://api.example.com/ws"})
+
+	previousPusher := pushActiveContext
+	t.Cleanup(func() { pushActiveContext = previousPusher })
+
+	called := false
+	pushActiveContext = func(client *http.Client, baseURL, authToken, contextName string) error {
+		called = true
+		return nil
+	}
+
+	if _, err := runCmd(t, "context", "use", "team:acme"); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	if called {
+		t.Fatal("pushActiveContext should not be called without auth token")
+	}
+}
+
+// TestContextUseTolerates404FromOlderServer verifies that pushActiveContextHTTP
+// returns nil when the server returns 404, so older servers without the
+// route don't surface a confusing warning.
+func TestPushActiveContextHTTP_TolerantOf404(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	if err := pushActiveContextHTTP(server.Client(), server.URL, "tok", "personal"); err != nil {
+		t.Fatalf("404 should be soft: got %v", err)
+	}
+}
+
+// TestPushActiveContextHTTP_BodyShape verifies the wire format the server
+// expects: {"kind":"personal"} and {"kind":"team","slug":"<s>"}.
+func TestPushActiveContextHTTP_BodyShape(t *testing.T) {
+	tests := []struct {
+		contextName string
+		wantKind    string
+		wantSlug    string
+	}{
+		{"personal", "personal", ""},
+		{"team:acme", "team", "acme"},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.contextName, func(t *testing.T) {
+			var receivedBody struct {
+				Kind string `json:"kind"`
+				Slug string `json:"slug,omitempty"`
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, request *http.Request) {
+				if request.URL.Path != "/api/me/preferences/active-context" {
+					t.Errorf("path: got %q want %q", request.URL.Path, "/api/me/preferences/active-context")
+				}
+				if got := request.Header.Get("Authorization"); got != "Bearer tok" {
+					t.Errorf("auth header: got %q", got)
+				}
+				if err := json.NewDecoder(request.Body).Decode(&receivedBody); err != nil {
+					t.Fatalf("decode body: %v", err)
+				}
+				rw.WriteHeader(http.StatusNoContent)
+			}))
+			t.Cleanup(server.Close)
+
+			if err := pushActiveContextHTTP(server.Client(), server.URL, "tok", testCase.contextName); err != nil {
+				t.Fatalf("push: %v", err)
+			}
+			if receivedBody.Kind != testCase.wantKind {
+				t.Errorf("kind: got %q want %q", receivedBody.Kind, testCase.wantKind)
+			}
+			if receivedBody.Slug != testCase.wantSlug {
+				t.Errorf("slug: got %q want %q", receivedBody.Slug, testCase.wantSlug)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

`justtunnel context use` now syncs the selected context to the server so the WS worker handshake can resolve the team without `team_slug` on every dial. Local config remains the source of truth — push failures degrade to a stderr warning so offline use still works.

Body shape matches the existing server endpoint (`POST /api/me/preferences/active-context`):
- `personal` → `{"kind":"personal"}`
- `team:<slug>` → `{"kind":"team","slug":"<slug>"}`

The endpoint now actually persists (paired with justtunnel-server#44).

## Test plan
- [x] `go vet ./...`
- [x] `go test -race ./...` — 641 passed across 12 packages
- [x] New tests cover: token-present push, logged-out skip, 404-tolerance against older servers, body shape per context kind

Closes #44
