### PR TITLE
qa followups: cli error handling, messaging, validation

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -181,6 +181,49 @@ func runContextUse(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
+	// Membership validation for team contexts. Without this, `context use
+	// team:<bogus>` silently succeeds against a server that has never
+	// heard of the team, and subsequent commands fail with downstream
+	// 403/404s instead of the real cause. See justtunnel-cli#49.
+	//
+	// We only validate when the user is authenticated AND the server
+	// supports the memberships endpoint. If it doesn't, fall through to
+	// the previous behavior so older servers still work.
+	if cfg.AuthToken != "" && strings.HasPrefix(name, config.TeamContextPrefix) {
+		baseURL, parseErr := apiBaseURL(cfg.ServerURL)
+		if parseErr == nil {
+			memberships, supported, fetchErr := fetchMemberships(nil, baseURL, cfg.AuthToken)
+			switch {
+			case fetchErr != nil && isNetworkError(fetchErr):
+				// Offline / unreachable server: warn and proceed so the
+				// user can keep working without connectivity.
+				fmt.Fprintf(os.Stderr,
+					"warning: could not verify team membership (offline?): %v\n", fetchErr)
+			case fetchErr != nil:
+				// Structured server error (4xx/5xx other than 404):
+				// surface so the user knows validation failed.
+				return fmt.Errorf("verify team membership: %w", fetchErr)
+			case supported:
+				slug := strings.TrimPrefix(name, config.TeamContextPrefix)
+				found := false
+				for _, mem := range memberships {
+					if mem.TeamSlug == slug {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return display.InputError(fmt.Sprintf(
+						"you are not a member of %s — run `justtunnel context list` to see available teams",
+						name,
+					))
+				}
+			}
+			// supported=false (older server): fall through; we cannot
+			// verify and forcing a hard error would break compatibility.
+		}
+	}
+
 	if err := config.SetCurrentContext(cfg, name); err != nil {
 		return fmt.Errorf("set context: %w", err)
 	}

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -383,3 +383,96 @@ func TestFetchMembershipsHTTP404(t *testing.T) {
 		t.Errorf("memberships should be nil on 404, got %v", memberships)
 	}
 }
+
+// TestContextUseRejectsNonMemberTeam verifies the membership validation
+// added for justtunnel-cli#49: `context use team:<bogus>` must error
+// (non-zero exit) when the server's memberships endpoint reports the
+// user is not a member, instead of silently accepting the slug.
+func TestContextUseRejectsNonMemberTeam(t *testing.T) {
+	stubServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/memberships" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Write([]byte(`{"memberships":[{"team_slug":"acme"}]}`))
+	}))
+	defer stubServer.Close()
+
+	resetContextState(t, &config.Config{
+		AuthToken: "tok",
+		ServerURL: httpToWS(stubServer.URL) + "/ws",
+	})
+
+	_, err := runCmd(t, "context", "use", "team:does-not-exist")
+	if err == nil {
+		t.Fatal("expected error for non-member team, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a member") {
+		t.Errorf("error should mention membership: got %v", err)
+	}
+
+	// Config must be unchanged — the user did not switch.
+	loaded, loadErr := config.Load(cfgFile)
+	if loadErr != nil {
+		t.Fatalf("load: %v", loadErr)
+	}
+	if loaded.CurrentContext == "team:does-not-exist" {
+		t.Errorf("config should not have been mutated; got CurrentContext=%q",
+			loaded.CurrentContext)
+	}
+}
+
+// TestContextUseAcceptsMemberTeam complements TestContextUseRejectsNonMemberTeam
+// by verifying the happy path still works after membership validation.
+func TestContextUseAcceptsMemberTeam(t *testing.T) {
+	stubServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/memberships":
+			writer.Header().Set("Content-Type", "application/json")
+			writer.Write([]byte(`{"memberships":[{"team_slug":"acme"}]}`))
+		case "/api/me/preferences/active-context":
+			writer.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer stubServer.Close()
+
+	resetContextState(t, &config.Config{
+		AuthToken: "tok",
+		ServerURL: httpToWS(stubServer.URL) + "/ws",
+	})
+
+	if _, err := runCmd(t, "context", "use", "team:acme"); err != nil {
+		t.Fatalf("expected success for member team: %v", err)
+	}
+	loaded, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded.CurrentContext != "team:acme" {
+		t.Errorf("CurrentContext: got %q want %q", loaded.CurrentContext, "team:acme")
+	}
+}
+
+// TestContextUseTolerates404FromOlderServer verifies older servers (no
+// /api/memberships route) still allow `context use` so the CLI doesn't
+// break compatibility. The previous behavior is preserved when supported
+// is false.
+func TestContextUseTolerates404FromOlderServer(t *testing.T) {
+	stubServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		// Every endpoint returns 404 — simulating an older server.
+		http.NotFound(writer, request)
+	}))
+	defer stubServer.Close()
+
+	resetContextState(t, &config.Config{
+		AuthToken: "tok",
+		ServerURL: httpToWS(stubServer.URL) + "/ws",
+	})
+
+	if _, err := runCmd(t, "context", "use", "team:acme"); err != nil {
+		t.Fatalf("404 from /api/memberships should not block context use: %v", err)
+	}
+}

--- a/cmd/worker_install.go
+++ b/cmd/worker_install.go
@@ -403,24 +403,22 @@ func serviceBackendForOS(goos string) string {
 }
 
 // workerURL derives the public URL for a worker subdomain from the
-// configured server URL. The transformation is:
+// configured server URL. The server routes by host (subdomain), not by
+// path, so the URL is always built by injecting <subdomain> into the
+// host portion of the server URL. The transformation is:
 //
 //   - Convert ws/wss → http/https.
-//   - If the host begins with "api." AND the URL carries no port, strip
-//     the "api." prefix and prepend "<subdomain>.".
+//   - Strip a leading "api." from the host so we don't end up with
+//     "<sub>.api.example.com" when the host is "api.example.com".
+//   - Prepend "<subdomain>." to the resulting host (port preserved).
 //     e.g. wss://api.justtunnel.dev/ws + "build--acme" → https://build--acme.justtunnel.dev
-//   - Otherwise (localhost, custom domain, "api."-prefixed host with an
-//     explicit port like dev/staging splits, or any non-standard host),
-//     fall back to "<server>/<subdomain>" — less polished but always
-//     meaningful and unambiguous.
+//          ws://localhost:8080/ws       + "alpha--team" → http://alpha--team.localhost:8080
 //
-// Note: the "api." strip ONLY kicks in when no port is present.
-// Production hosts are bare; "api.example.com:8443" indicates a
-// dev/staging environment where the operator deliberately pinned a
-// port, and rewriting `api.example.com:8443` to
-// `<sub>.example.com:8443` would silently lose that signal. We instead
-// keep the original host and append "/<subdomain>" so the result still
-// resolves something the operator can click through to.
+// Previously this function fell back to a path-style form
+// (`<server>/<subdomain>`) for hosts that lacked a bare "api." prefix
+// (localhost, custom domains, api.* with an explicit port). That form
+// returned 404 because the reverse proxy keys on host, not path —
+// see justtunnel-cli#48.
 //
 // This lives in cmd because it's a CLI display concern, not a server URL
 // rule. If the URL shape ever moves into the worker config (e.g. as
@@ -448,18 +446,16 @@ func workerURL(serverURL, subdomain string) (string, error) {
 	// the secret into terminal scrollback and CI logs.
 	parsed.User = nil
 
-	host := parsed.Host
-	// Only transform when host has the literal "api." prefix AND port is
-	// empty — production hosts are bare. localhost:8080 has a port and
-	// would never carry the api. prefix anyway, so this gate keeps the
-	// "fall back to /<sub>" branch simple.
-	if strings.HasPrefix(host, "api.") && parsed.Port() == "" {
-		baseDomain := strings.TrimPrefix(host, "api.")
-		parsed.Host = subdomain + "." + baseDomain
-		return parsed.String(), nil
+	hostname := parsed.Hostname()
+	port := parsed.Port()
+	// Strip a leading "api." so we end up with `<sub>.justtunnel.dev`
+	// rather than `<sub>.api.justtunnel.dev`. Hosts that don't carry the
+	// prefix (localhost, tunnels.example.com) keep their full host.
+	hostname = strings.TrimPrefix(hostname, "api.")
+	newHost := subdomain + "." + hostname
+	if port != "" {
+		newHost += ":" + port
 	}
-	// Fallback: append /<subdomain> to the server URL. Documented as a
-	// less-polished form for non-standard server URLs.
-	parsed.Path = "/" + subdomain
+	parsed.Host = newHost
 	return parsed.String(), nil
 }

--- a/cmd/worker_install_test.go
+++ b/cmd/worker_install_test.go
@@ -569,33 +569,35 @@ func TestWorkerURLForConfigured(t *testing.T) {
 			want:      "https://alpha--team.justtunnel.dev",
 		},
 		{
-			name:      "localhost dev fallback",
+			// Localhost dev: server routes by host (subdomain), so the
+			// URL must put the subdomain on the host side. The previous
+			// path-form fallback (http://localhost:8080/<sub>) returned
+			// 404 against the real server — see #48.
+			name:      "localhost dev",
 			serverURL: "ws://localhost:8080/ws",
 			subdomain: "alpha--team",
-			want:      "http://localhost:8080/alpha--team",
+			want:      "http://alpha--team.localhost:8080",
 		},
 		{
 			name:      "custom domain without api prefix",
 			serverURL: "wss://tunnels.example.com/ws",
 			subdomain: "alpha--team",
-			want:      "https://tunnels.example.com/alpha--team",
+			want:      "https://alpha--team.tunnels.example.com",
 		},
 		{
 			// Dev/staging splits sometimes pin api.* on a non-default
-			// port. We deliberately do NOT strip "api." in that case
-			// because rewriting `api.example.com:8443` to
-			// `<sub>.example.com:8443` would silently change the
-			// host's intent. Fall back to /<subdomain>.
-			name:      "api host with explicit port falls back to path form",
+			// port. We still strip "api." and prepend the subdomain so
+			// the URL routes; the explicit port is preserved.
+			name:      "api host with explicit port",
 			serverURL: "https://api.example.com:8443/ws",
 			subdomain: "build--acme",
-			want:      "https://api.example.com:8443/build--acme",
+			want:      "https://build--acme.example.com:8443",
 		},
 		{
 			name:      "api host with explicit port wss scheme",
 			serverURL: "wss://api.example.com:8443/ws",
 			subdomain: "build--acme",
-			want:      "https://api.example.com:8443/build--acme",
+			want:      "https://build--acme.example.com:8443",
 		},
 	}
 	for _, tc := range cases {
@@ -805,13 +807,16 @@ func TestWorkerURLStripsUserinfo(t *testing.T) {
 		t.Errorf("workerURL = %q, want %q", got, want)
 	}
 
-	// Path-form fallback (custom domain): same expectation.
+	// Custom domain: still must strip userinfo.
 	got2, err := workerURL("wss://user:pass@tunnels.example.com/ws", "alpha--team")
 	if err != nil {
 		t.Fatalf("workerURL: %v", err)
 	}
 	if strings.Contains(got2, "user") || strings.Contains(got2, "pass") {
-		t.Errorf("workerURL leaked userinfo on fallback path, got: %q", got2)
+		t.Errorf("workerURL leaked userinfo on custom-domain path, got: %q", got2)
+	}
+	if want2 := "https://alpha--team.tunnels.example.com"; got2 != want2 {
+		t.Errorf("workerURL = %q, want %q", got2, want2)
 	}
 }
 

--- a/cmd/worker_list.go
+++ b/cmd/worker_list.go
@@ -11,6 +11,12 @@ import (
 	"github.com/justtunnel/justtunnel-cli/internal/worker"
 )
 
+// workerListAll controls whether `worker list` includes quarantined
+// rows. Default false hides them so a freshly-deleted worker doesn't
+// linger in the listing for 30 days; pass --all to see the soft-deleted
+// rows (e.g. before they're permanently removed). See justtunnel-cli#50.
+var workerListAll bool
+
 var workerListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List workers for the active team context",
@@ -19,6 +25,8 @@ var workerListCmd = &cobra.Command{
 }
 
 func init() {
+	workerListCmd.Flags().BoolVar(&workerListAll, "all", false,
+		"include quarantined workers (soft-deleted; permanently removed after 30 days)")
 	workerCmd.AddCommand(workerListCmd)
 }
 
@@ -49,6 +57,9 @@ func runWorkerList(cmd *cobra.Command, args []string) error {
 	}
 
 	rows := mergeWorkers(serverWorkers, localWorkers, ctxName)
+	if !workerListAll {
+		rows = filterQuarantined(rows)
+	}
 
 	out := cmd.OutOrStdout()
 	if len(rows) == 0 {
@@ -113,6 +124,13 @@ func mergeWorkers(server []workerAPI, local []worker.Config, ctxName string) []w
 		if loc.WorkerID != "" {
 			if existing, ok := byID[loc.WorkerID]; ok {
 				existing.Presence = "synced"
+				// F-07: when the server omits subdomain in its list
+				// response, fall back to the locally-derived value
+				// rather than rendering "-" for every row. See
+				// justtunnel-cli#51.
+				if existing.Subdomain == "" {
+					existing.Subdomain = loc.Subdomain
+				}
 				matched[loc.Name] = true
 				continue
 			}
@@ -126,6 +144,9 @@ func mergeWorkers(server []workerAPI, local []worker.Config, ctxName string) []w
 			for _, row := range rows {
 				if row.Name == loc.Name {
 					row.Presence = "synced"
+					if row.Subdomain == "" {
+						row.Subdomain = loc.Subdomain
+					}
 					matched[loc.Name] = true
 					break
 				}
@@ -148,6 +169,21 @@ func mergeWorkers(server []workerAPI, local []worker.Config, ctxName string) []w
 		out = append(out, *row)
 	}
 	sort.Slice(out, func(left, right int) bool { return out[left].Name < out[right].Name })
+	return out
+}
+
+// filterQuarantined drops rows that the server has already soft-deleted
+// (status=retired_quarantined). The default `worker list` view hides
+// these so a freshly-deleted worker doesn't linger for 30 days; pass
+// --all to see them. See justtunnel-cli#50.
+func filterQuarantined(rows []workerRow) []workerRow {
+	out := rows[:0]
+	for _, row := range rows {
+		if row.Status == "retired_quarantined" {
+			continue
+		}
+		out = append(out, row)
+	}
 	return out
 }
 

--- a/cmd/worker_rm.go
+++ b/cmd/worker_rm.go
@@ -129,8 +129,14 @@ func runWorkerRm(cmd *cobra.Command, args []string) error {
 			name, workerID,
 		)
 	} else {
+		// The server soft-deletes (status=retired_quarantined) and a
+		// background reaper removes the row 30 days later — see #70 /
+		// admin-lifecycle. Reflect that in the success message so the
+		// user isn't confused by the worker still showing up in
+		// `worker list --all`. See justtunnel-cli#50.
 		fmt.Fprintf(cmd.OutOrStdout(),
-			"Deleted worker %q (server + local).\n", name,
+			"Quarantined worker %q (local config removed; permanent server-side removal in 30 days).\n",
+			name,
 		)
 	}
 	return nil

--- a/cmd/worker_start.go
+++ b/cmd/worker_start.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -64,18 +63,18 @@ func runWorkerStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Tee logs to both stderr (for foreground operators) and the per-worker
-	// log file (for `worker logs` in #31). The file is opened in append mode
-	// with 0600 perms — see worker.OpenLogFile.
-	logFile, err := worker.OpenLogFile(name)
-	if err != nil {
-		return err
-	}
-	defer logFile.Close()
-
+	// Logs go to stderr only. The platform supervisor (launchd on macOS,
+	// systemd-user on Linux) is configured to redirect stderr to the
+	// per-worker log file at ~/.justtunnel/logs/worker-<name>.log, which
+	// is what `worker logs` reads. Writing to the file in-process AND
+	// having the supervisor capture stderr to the same path produced
+	// duplicate lines in the log file (F-10) — see justtunnel-cli#51.
+	//
+	// Foreground use without a supervisor (`justtunnel worker start
+	// <name>` directly) emits to stderr only; that's intentional, since
+	// the operator is watching the terminal in that mode.
 	logLevel := parseLogLevel(cfg.LogLevel)
-	multiWriter := io.MultiWriter(cmd.ErrOrStderr(), logFile)
-	logger := slog.New(slog.NewTextHandler(multiWriter, &slog.HandlerOptions{
+	logger := slog.New(slog.NewTextHandler(cmd.ErrOrStderr(), &slog.HandlerOptions{
 		Level: logLevel,
 	}))
 
@@ -113,9 +112,10 @@ func runWorkerStart(cmd *cobra.Command, args []string) error {
 
 	runErr := runner.Run(ctx)
 
-	// Disambiguate the three exit modes for the operator and the caller:
+	// Disambiguate the four exit modes for the operator and the caller:
 	//   * context cancelled (SIGINT/SIGTERM) → exit 0
-	//   * terminal close code (4403/4409)    → return error so cobra exits 1
+	//   * 403 forbidden                      → display.ForbiddenError (no re-auth misdirection)
+	//   * 401 / terminal close code          → return error so cobra exits 1
 	//   * any other error                    → return error
 	switch {
 	case runErr == nil:
@@ -123,6 +123,15 @@ func runWorkerStart(cmd *cobra.Command, args []string) error {
 	case errors.Is(runErr, context.Canceled):
 		logger.Info("worker stopped (signal received)", "worker", workerCfg.Name)
 		return nil
+	case errors.Is(runErr, worker.ErrForbidden):
+		// Most common cause for a worker 403 is creating the worker via
+		// `worker create` (no service token) and then trying to start
+		// it directly. Steer the operator there instead of suggesting
+		// re-auth, which won't help. See justtunnel-cli#47.
+		return display.ForbiddenError(
+			fmt.Sprintf("worker %q rejected by server (403)", workerCfg.Name),
+			fmt.Sprintf("This is not an authentication problem. If %[1]q was created with `worker create`, run `justtunnel worker install %[1]s` to provision a service token. Other causes: the team is suspended or your membership was revoked.", workerCfg.Name),
+		)
 	default:
 		return runErr
 	}

--- a/cmd/worker_test.go
+++ b/cmd/worker_test.go
@@ -31,6 +31,7 @@ import (
 //   - workerInstallNonInteractive (worker_install.go)
 //   - workerUninstallDeleteOnServer (worker_uninstall.go)
 //   - workerUninstallForce (worker_uninstall.go)
+//   - workerListAll (worker_list.go)
 func resetWorkerState(t *testing.T, cfg *config.Config) string {
 	t.Helper()
 	path := resetContextState(t, cfg)
@@ -41,12 +42,14 @@ func resetWorkerState(t *testing.T, cfg *config.Config) string {
 	workerInstallNonInteractive = false
 	workerUninstallDeleteOnServer = false
 	workerUninstallForce = false
+	workerListAll = false
 	t.Cleanup(func() {
 		workerRmDeleteOnServer = false
 		workerInstallNoLinger = false
 		workerInstallNonInteractive = false
 		workerUninstallDeleteOnServer = false
 		workerUninstallForce = false
+		workerListAll = false
 	})
 	return path
 }
@@ -637,5 +640,120 @@ func TestResolveTeamIDRejectsMalformedSlugs(t *testing.T) {
 				t.Errorf("error should mention context, got: %v", err)
 			}
 		})
+	}
+}
+
+// TestWorkerRmDeleteOnServerMessageReflectsQuarantine guards against the
+// regression in justtunnel-cli#50 where `rm --delete-on-server` printed
+// "Deleted worker (server + local)" even though the server only
+// soft-deletes and the worker remains visible (as retired_quarantined)
+// in `worker list --all` for 30 days.
+func TestWorkerRmDeleteOnServerMessageReflectsQuarantine(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method == http.MethodGet && request.URL.Path == "/api/teams/team-alpha/workers" {
+			writer.Header().Set("Content-Type", "application/json")
+			writer.Write([]byte(`{"workers":[{"id":"wkr_x","name":"alice","team_id":"team-alpha"}]}`))
+			return
+		}
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(`{"status":"deleted"}`))
+	}))
+	defer stub.Close()
+
+	resetWorkerState(t, teamCfg(stub.URL))
+	if err := worker.Write(&worker.Config{
+		WorkerID: "wkr_x", Name: "alice", Context: "team:team-alpha", ServiceBackend: "none",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	out, err := runCmd(t, "worker", "rm", "alice", "--delete-on-server")
+	if err != nil {
+		t.Fatalf("rm: %v", err)
+	}
+	// New honest messaging — must NOT claim outright deletion.
+	if strings.Contains(out, "Deleted worker") {
+		t.Errorf("output still claims permanent deletion (#50 regression): %s", out)
+	}
+	if !strings.Contains(out, "Quarantined") || !strings.Contains(out, "30 days") {
+		t.Errorf("output should describe quarantine + 30-day reaper window: %s", out)
+	}
+}
+
+// TestWorkerListHidesQuarantinedByDefault guards justtunnel-cli#50: the
+// default `worker list` view must NOT display rows the server has
+// soft-deleted, otherwise a user who just ran `rm --delete-on-server`
+// sees their "deleted" worker still listed.
+func TestWorkerListHidesQuarantinedByDefault(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Write([]byte(`{"workers":[
+		    {"id":"wkr_a","name":"alice","team_id":"team-alpha","subdomain":"alice--team-alpha","status":"online"},
+		    {"id":"wkr_z","name":"zombie","team_id":"team-alpha","subdomain":"zombie--team-alpha","status":"retired_quarantined"}
+		]}`))
+	}))
+	defer stub.Close()
+
+	resetWorkerState(t, teamCfg(stub.URL))
+
+	out, err := runCmd(t, "worker", "list")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(out, "alice") {
+		t.Errorf("active worker should be listed: %s", out)
+	}
+	if strings.Contains(out, "zombie") {
+		t.Errorf("quarantined worker should be hidden by default: %s", out)
+	}
+}
+
+// TestWorkerListAllShowsQuarantined verifies the --all flag opts the
+// quarantined rows back in.
+func TestWorkerListAllShowsQuarantined(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Write([]byte(`{"workers":[
+		    {"id":"wkr_z","name":"zombie","team_id":"team-alpha","subdomain":"zombie--team-alpha","status":"retired_quarantined"}
+		]}`))
+	}))
+	defer stub.Close()
+
+	resetWorkerState(t, teamCfg(stub.URL))
+
+	out, err := runCmd(t, "worker", "list", "--all")
+	if err != nil {
+		t.Fatalf("list --all: %v", err)
+	}
+	if !strings.Contains(out, "zombie") {
+		t.Errorf("--all should reveal quarantined rows: %s", out)
+	}
+}
+
+// TestWorkerListSubdomainFallsBackToLocal guards F-07 (#51): when the
+// server omits subdomain in its list response, the row should fall back
+// to the locally-derived value rather than rendering "-".
+func TestWorkerListSubdomainFallsBackToLocal(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		// subdomain field intentionally omitted server-side.
+		writer.Write([]byte(`{"workers":[{"id":"wkr_a","name":"alice","team_id":"team-alpha","status":"offline"}]}`))
+	}))
+	defer stub.Close()
+
+	resetWorkerState(t, teamCfg(stub.URL))
+	if err := worker.Write(&worker.Config{
+		WorkerID: "wkr_a", Name: "alice", Context: "team:team-alpha",
+		Subdomain: "alice--team-alpha", ServiceBackend: "none",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	out, err := runCmd(t, "worker", "list")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(out, "alice--team-alpha") {
+		t.Errorf("subdomain should fall back to local value, got: %s", out)
 	}
 }

--- a/cmd/worker_uninstall.go
+++ b/cmd/worker_uninstall.go
@@ -212,6 +212,17 @@ func runWorkerUninstall(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(cmd.OutOrStdout(), "worker %q already uninstalled\n", name)
 		return nil
 	}
+	if workerUninstallDeleteOnServer {
+		// Server soft-deletes (status=retired_quarantined); a reaper
+		// removes the row 30 days later. Tell the operator so they
+		// aren't surprised by `worker list --all` still showing the
+		// name. See justtunnel-cli#50.
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"Uninstalled worker %q (server-side row quarantined; permanent removal in 30 days)\n",
+			name,
+		)
+		return nil
+	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Uninstalled worker %q\n", name)
 	return nil
 }

--- a/internal/display/errors.go
+++ b/internal/display/errors.go
@@ -12,6 +12,12 @@ const (
 	CategoryAuth
 	CategoryInput
 	CategoryServer
+	// CategoryForbidden is for 403 / policy-rejection style errors where
+	// the user IS authenticated but the requested action is not allowed
+	// (plan limits, missing service token, suspended team, etc.). It
+	// renders without the misleading "re-authenticate" suggestion that
+	// CategoryAuth carries. See justtunnel-cli#47.
+	CategoryForbidden
 )
 
 type CLIError struct {
@@ -55,6 +61,18 @@ func ServerError(message string) *CLIError {
 	}
 }
 
+// ForbiddenError builds a 403-style CLIError. Suggestion is caller-supplied
+// because the right next step depends on context (plan upgrade, install a
+// service token, contact billing, etc.) — anything generic risks
+// reintroducing the "re-authenticate" misdirection that #47 fixed.
+func ForbiddenError(message, suggestion string) *CLIError {
+	return &CLIError{
+		Category:   CategoryForbidden,
+		Message:    message,
+		Suggestion: suggestion,
+	}
+}
+
 func PrintError(err error) {
 	var cliErr *CLIError
 	if !errors.As(err, &cliErr) {
@@ -75,6 +93,9 @@ func PrintError(err error) {
 		prefix = "Error"
 	case CategoryServer:
 		prefix = "Server error"
+	case CategoryForbidden:
+		prefix = "Forbidden"
+		prefixColor = colorYellow
 	}
 
 	fmt.Fprintln(output)

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -138,6 +138,7 @@ func (t *Tunnel) connect(ctx context.Context) error {
 }
 
 func (t *Tunnel) connectWithURL(ctx context.Context, dialURL string) error {
+	t.logger.Debug("dialing tunnel websocket", "url", dialURL)
 	opts := &websocket.DialOptions{}
 	if t.authToken != "" {
 		opts.HTTPHeader = http.Header{
@@ -153,8 +154,23 @@ func (t *Tunnel) connectWithURL(ctx context.Context, dialURL string) error {
 
 	conn, httpResp, err := websocket.Dial(ctx, dialURL, opts)
 	if err != nil {
-		if httpResp != nil && (httpResp.StatusCode == http.StatusUnauthorized || httpResp.StatusCode == http.StatusForbidden) {
-			return display.AuthError(fmt.Sprintf("server returned %d: %v", httpResp.StatusCode, err))
+		if httpResp != nil {
+			switch httpResp.StatusCode {
+			case http.StatusUnauthorized:
+				return display.AuthError(fmt.Sprintf("server returned %d: %v", httpResp.StatusCode, err))
+			case http.StatusForbidden:
+				// 403 means "authenticated but not allowed". The most
+				// common causes for tunnel dial are: subdomain
+				// reservation requires Pro plan, the requested
+				// subdomain is taken, or the account/team is
+				// suspended. None of those are fixed by re-auth, so
+				// we deliberately steer the user away from
+				// `justtunnel auth`. See justtunnel-cli#47.
+				return display.ForbiddenError(
+					fmt.Sprintf("server returned 403: %v", err),
+					"This is not an authentication problem. Common causes: requested subdomain requires the Pro plan, the subdomain is in use, or your account/team is suspended.",
+				)
+			}
 		}
 		return fmt.Errorf("dial: %w", err)
 	}
@@ -192,6 +208,12 @@ func (t *Tunnel) connectWithURL(ctx context.Context, dialURL string) error {
 	t.reconnectToken = assigned.ReconnectToken
 	t.reconnectIssuedAt = assigned.ReconnectIssuedAt
 	t.passwordProtected = assigned.PasswordProtected
+	t.logger.Debug("tunnel assigned",
+		"subdomain", assigned.Subdomain,
+		"url", assigned.URL,
+		"tunnel_id", assigned.TunnelID,
+		"password_protected", assigned.PasswordProtected,
+	)
 
 	// Only fire OnConnected for the initial connection, not during reconnects.
 	if !t.reconnecting && t.callbacks.OnConnected != nil {
@@ -220,6 +242,11 @@ func (t *Tunnel) readLoop(ctx context.Context) error {
 
 		switch parsed := frame.(type) {
 		case *RequestFrame:
+			t.logger.Debug("incoming request frame",
+				"id", parsed.ID,
+				"method", parsed.Method,
+				"path", parsed.Path,
+			)
 			t.wg.Add(1)
 			go t.handleRequest(ctx, parsed)
 		case *ErrorFrame:
@@ -290,6 +317,17 @@ func (t *Tunnel) writeJSONTo(ctx context.Context, targetConn *websocket.Conn, v 
 func isAuthError(err error) bool {
 	var cliErr *display.CLIError
 	return errors.As(err, &cliErr) && cliErr.Category == display.CategoryAuth
+}
+
+// isTerminalDialError reports whether reconnecting is futile. Auth (401)
+// won't fix itself across attempts, and Forbidden (403) policy decisions
+// won't either — keep retrying would just hammer the server.
+func isTerminalDialError(err error) bool {
+	var cliErr *display.CLIError
+	if !errors.As(err, &cliErr) {
+		return false
+	}
+	return cliErr.Category == display.CategoryAuth || cliErr.Category == display.CategoryForbidden
 }
 
 // buildReconnectURL appends reconnect token parameters to the server URL
@@ -364,9 +402,13 @@ func (t *Tunnel) reconnect(ctx context.Context) error {
 		if err := t.connectWithURL(ctx, reconnectURL); err != nil {
 			t.logger.Error("reconnect attempt failed", "attempt", attempt, "error", err)
 
-			// Don't retry on auth errors — credentials won't change between attempts.
+			// Don't retry on auth or forbidden errors — credentials and
+			// policy decisions won't change between attempts.
 			if isAuthError(err) {
 				return display.AuthError("authentication failed during reconnect - run 'justtunnel auth' to re-authenticate")
+			}
+			if isTerminalDialError(err) {
+				return err
 			}
 
 			backoff *= 2

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -13,6 +14,8 @@ import (
 	"time"
 
 	"nhooyr.io/websocket"
+
+	"github.com/justtunnel/justtunnel-cli/internal/display"
 )
 
 func TestTunnelEndToEnd(t *testing.T) {
@@ -124,4 +127,62 @@ func TestTunnelEndToEnd(t *testing.T) {
 
 	// Wait for server handler to finish so t.Errorf calls are safe
 	<-serverDone
+}
+
+// TestTunnelDial403MapsToForbidden guards justtunnel-cli#47: a 403 from
+// the WebSocket dial must surface as a CategoryForbidden CLIError, NOT
+// a CategoryAuth one. The user is authenticated; suggesting they
+// re-authenticate is misleading and sends them down the wrong path.
+func TestTunnelDial403MapsToForbidden(t *testing.T) {
+	wsServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		http.Error(writer, "subdomain reserved for Pro plan", http.StatusForbidden)
+	}))
+	defer wsServer.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	tun := New(wsURL, "http://localhost:0", "", logger, Callbacks{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := tun.Run(ctx)
+	if err == nil {
+		t.Fatal("expected dial error on 403, got nil")
+	}
+	var cliErr *display.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected CLIError, got %T: %v", err, err)
+	}
+	if cliErr.Category != display.CategoryForbidden {
+		t.Errorf("category: got %v, want CategoryForbidden (must NOT be CategoryAuth)", cliErr.Category)
+	}
+}
+
+// TestTunnelDial401MapsToAuth is the contrast case: a 401 still maps to
+// CategoryAuth (re-authentication IS the right next step there).
+func TestTunnelDial401MapsToAuth(t *testing.T) {
+	wsServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		http.Error(writer, "invalid token", http.StatusUnauthorized)
+	}))
+	defer wsServer.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	tun := New(wsURL, "http://localhost:0", "", logger, Callbacks{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := tun.Run(ctx)
+	if err == nil {
+		t.Fatal("expected dial error on 401, got nil")
+	}
+	var cliErr *display.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected CLIError, got %T: %v", err, err)
+	}
+	if cliErr.Category != display.CategoryAuth {
+		t.Errorf("category: got %v, want CategoryAuth", cliErr.Category)
+	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,32 @@
 package version
 
-// Set via -ldflags at build time.
+import "runtime/debug"
+
+// Set via -ldflags at build time. When unset (e.g. a local
+// `go build ./...` without ldflags), init() below falls back to
+// debug.ReadBuildInfo so dev binaries still report a meaningful
+// commit/date instead of "unknown". See justtunnel-cli#51 (F-01).
 var (
 	Version = "dev"
 	Commit  = "unknown"
 	Date    = "unknown"
 )
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			if Commit == "unknown" && setting.Value != "" {
+				Commit = setting.Value
+			}
+		case "vcs.time":
+			if Date == "unknown" && setting.Value != "" {
+				Date = setting.Value
+			}
+		}
+	}
+}

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -33,10 +33,19 @@ func (te *TerminalError) Error() string {
 }
 
 // ErrAuthFailed is returned (wrapped) by a Dialer when the server rejects
-// the worker handshake with 401 or 403. The token will not change on its
-// own, so Runner.Run treats this as terminal — same semantics as
-// TerminalError — to avoid a tight retry loop hammering the server.
+// the worker handshake with 401. The token will not change on its own, so
+// Runner.Run treats this as terminal — same semantics as TerminalError —
+// to avoid a tight retry loop hammering the server.
 var ErrAuthFailed = errors.New("worker: auth failed")
+
+// ErrForbidden is returned (wrapped) by a Dialer when the server rejects
+// the worker handshake with 403. Unlike 401 this is NOT an
+// authentication problem — common causes are a worker registered without
+// a service token (created via `worker create` instead of
+// `worker install`) or a suspended team. Runner.Run treats this as
+// terminal because the policy decision won't change on retry. See
+// justtunnel-cli#47.
+var ErrForbidden = errors.New("worker: forbidden")
 
 // Terminal close codes per tech spec §7. Both indicate the operator must
 // take action — restart the worker won't help.
@@ -269,6 +278,11 @@ func (r *Runner) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("worker: build dial URL: %w", err)
 	}
+	r.Logger.Debug("worker runner starting",
+		"worker", r.WorkerName,
+		"subdomain", r.Subdomain,
+		"dial_url", dialURL,
+	)
 
 	// dialAttempt tracks consecutive failed dials (network errors).
 	// disconnectAttempt tracks consecutive flapping disconnects (a connect
@@ -298,6 +312,14 @@ func (r *Runner) Run(ctx context.Context) error {
 			// server.
 			if errors.Is(dialErr, ErrAuthFailed) {
 				r.Logger.Error("worker auth failed (no reconnect)",
+					"worker", r.WorkerName,
+					"error", dialErr,
+				)
+				return dialErr
+			}
+			// 403 / policy rejection is also terminal — see #47.
+			if errors.Is(dialErr, ErrForbidden) {
+				r.Logger.Error("worker forbidden by server (no reconnect)",
 					"worker", r.WorkerName,
 					"error", dialErr,
 				)
@@ -590,10 +612,19 @@ func (rd *realDialer) Dial(ctx context.Context, dialURL string) (workerConn, err
 	if err != nil {
 		// Surface auth failures distinctly so callers can decide whether
 		// reconnecting is futile (it is — the token won't change).
-		if httpResp != nil && (httpResp.StatusCode == http.StatusUnauthorized || httpResp.StatusCode == http.StatusForbidden) {
-			// Wrap with ErrAuthFailed so Runner.Run can match via
-			// errors.Is and exit terminally instead of looping.
-			return nil, fmt.Errorf("worker: dial returned %d: %w", httpResp.StatusCode, ErrAuthFailed)
+		if httpResp != nil {
+			switch httpResp.StatusCode {
+			case http.StatusUnauthorized:
+				// Wrap with ErrAuthFailed so Runner.Run can match via
+				// errors.Is and exit terminally instead of looping.
+				return nil, fmt.Errorf("worker: dial returned %d: %w", httpResp.StatusCode, ErrAuthFailed)
+			case http.StatusForbidden:
+				// 403 is "authenticated but not allowed" — distinct
+				// from 401. The cmd layer renders a non-misleading
+				// message instead of asking the operator to re-auth.
+				// See justtunnel-cli#47.
+				return nil, fmt.Errorf("worker: dial returned %d: %w", httpResp.StatusCode, ErrForbidden)
+			}
 		}
 		return nil, fmt.Errorf("worker: dial: %w", err)
 	}

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -355,17 +355,22 @@ func TestRunner_AuthFailureIsTerminal(t *testing.T) {
 }
 
 // TestRunner_AuthFailureForbidden is the 403 sibling of the 401 test —
-// same expectation: terminate immediately.
+// same exit-immediately expectation, but the runner must surface
+// ErrForbidden (not ErrAuthFailed) so the cmd layer can render a
+// non-misleading message. See justtunnel-cli#47.
 func TestRunner_AuthFailureForbidden(t *testing.T) {
 	dialer := &fakeDialer{
 		script: []dialResult{
-			{dialErr: fmt.Errorf("worker: dial returned 403: %w", ErrAuthFailed)},
+			{dialErr: fmt.Errorf("worker: dial returned 403: %w", ErrForbidden)},
 		},
 	}
 	runner := newTestRunner(dialer)
 	err := runner.Run(context.Background())
-	if !errors.Is(err, ErrAuthFailed) {
-		t.Fatalf("Run returned %v; want errors.Is(err, ErrAuthFailed)", err)
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("Run returned %v; want errors.Is(err, ErrForbidden)", err)
+	}
+	if errors.Is(err, ErrAuthFailed) {
+		t.Fatalf("403 must NOT surface as ErrAuthFailed (would trigger misleading 're-authenticate' UI)")
 	}
 	if got := atomic.LoadInt32(&dialer.attempts); got != 1 {
 		t.Fatalf("expected exactly 1 dial attempt; got %d", got)


### PR DESCRIPTION
Fixes the six QA-followup issues from the 2026-05-06 full-scope CLI pass.

## Changes

- **#48 worker URL format** — `worker install` now builds the public URL by injecting `<subdomain>` into the host portion of the API URL (e.g. `http://alpha--team.localhost:8080`). The previous path-style fallback (`http://localhost:8080/<sub>`) returned 404 because the reverse proxy keys on host, not path.
- **#49 bogus team accepted** — `context use team:<slug>` now hits `/api/memberships` first (when authed) and refuses to switch to a team the user is not a member of. Older servers without the route fall through with prior behavior.
- **#46 exit-0 on errors** — fixed transitively by #49: the `context use team:<bogus>` case now exits 1 because membership validation returns an error. The other cases listed in the issue (`auth not_a_valid_key`, `worker install --team asdff`) already exit 1 in the QA commit; verified by manual run.
- **#47 403 mislabeled as auth** — added `display.CategoryForbidden` and `display.ForbiddenError`. WebSocket dial in tunnel mode and worker dial in worker mode now branch on 403 vs 401:
  - 403 → "Forbidden" with a context-appropriate suggestion (plan/subdomain/service token), no `justtunnel auth` misdirection.
  - 401 → unchanged "Auth error: re-authenticate".
  - `worker.ErrForbidden` is a distinct sentinel from `worker.ErrAuthFailed`; the runner treats both as terminal but the cmd layer renders different messages.
- **#50 deletion message wrong** —
  - `worker rm <name> --delete-on-server` and `worker uninstall <name> --delete-on-server` now say "Quarantined ... permanent server-side removal in 30 days" instead of falsely claiming permanent deletion.
  - `worker list` filters out `retired_quarantined` rows by default; pass `--all` to see them.
- **#51 minor tracker** — all four sub-items addressed:
  - **F-01** version metadata: `internal/version` now falls back to `runtime/debug.ReadBuildInfo()` so `--version` reports a real commit/date even on a plain `go build` (no `-ldflags` required).
  - **F-04** `--log-level debug`: added `logger.Debug(...)` call sites in `internal/tunnel/tunnel.go` (dial start, tunnel assignment, incoming request frame) and `internal/worker/runner.go` (runner start) so the flag has visible effect.
  - **F-07** `worker list` SUBDOMAIN column always `-`: `mergeWorkers` now falls back to the locally-derived subdomain when the server response omits it.
  - **F-10** duplicated worker log lines: `worker start` no longer multi-writes to both stderr and the log file. The supervisor (launchd / systemd-user) already captures stderr to `~/.justtunnel/logs/worker-<name>.log`, so writing to the file in-process produced duplicate lines under supervised runs.

## Tests

- `cmd/context_test.go` — `TestContextUseRejectsNonMemberTeam`, `TestContextUseAcceptsMemberTeam`, `TestContextUseTolerates404FromOlderServer`.
- `cmd/worker_install_test.go` — `TestWorkerURLForConfigured` cases updated for subdomain-form URLs (localhost, custom domain, api+port).
- `cmd/worker_test.go` — `TestWorkerRmDeleteOnServerMessageReflectsQuarantine`, `TestWorkerListHidesQuarantinedByDefault`, `TestWorkerListAllShowsQuarantined`, `TestWorkerListSubdomainFallsBackToLocal`.
- `internal/tunnel/tunnel_test.go` — `TestTunnelDial403MapsToForbidden`, `TestTunnelDial401MapsToAuth`.
- `internal/worker/runner_test.go` — `TestRunner_AuthFailureForbidden` updated to use `ErrForbidden` and assert it does NOT match `ErrAuthFailed`.

`go vet ./... && go test -race ./...` → 650 passed in 12 packages.

Closes #46
Closes #47
Closes #48
Closes #49
Closes #50
Closes #51
