### PR TITLE
qa-2026-05-07: F-21 stale context annotation + F-20 --all flag wiring

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -253,8 +253,80 @@ func runContextShow(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 	active := config.ResolveContext(cfg, contextOverride)
+
+	// F-21: detect a stale team context — a slug that was set in an older
+	// binary (before write-side validation in justtunnel-cli#49) and has
+	// since been deleted or had the user removed. We annotate but do not
+	// mutate config: the user clears it explicitly with `context use
+	// personal`. Failures to verify (offline, unsupported endpoint, network)
+	// fall through silently so `context show` keeps working without a
+	// reachable server.
+	if note := stalenessAnnotation(cfg, active); note != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n", active, note)
+		return nil
+	}
+
 	fmt.Fprintln(cmd.OutOrStdout(), active)
 	return nil
+}
+
+// stalenessAnnotation returns a parenthesized note when the active context
+// references a team the user is not a member of, or "" when the context is
+// either valid, personal, or cannot be verified (offline, older server,
+// ULID-shaped identifier we cannot resolve via the slug-keyed memberships
+// endpoint). Callers append the annotation to the printed context.
+func stalenessAnnotation(cfg *config.Config, active string) string {
+	if cfg == nil || cfg.AuthToken == "" {
+		return ""
+	}
+	if !strings.HasPrefix(active, config.TeamContextPrefix) {
+		return ""
+	}
+	identifier := strings.TrimPrefix(active, config.TeamContextPrefix)
+	if identifier == "" || looksLikeULID(identifier) {
+		// ULIDs are addressed by Team.ID, not slug — the memberships
+		// endpoint returns slugs, so we cannot prove staleness here.
+		// Fail open rather than annotate a valid ULID-shaped context.
+		return ""
+	}
+
+	baseURL, err := apiBaseURL(cfg.ServerURL)
+	if err != nil {
+		return ""
+	}
+	memberships, supported, err := fetchMemberships(nil, baseURL, cfg.AuthToken)
+	if err != nil || !supported {
+		// Unsupported endpoint or any fetch error: fail open. Loud server
+		// errors (4xx/5xx) are intentionally swallowed here — `context
+		// show` is a read-only diagnostic and shouldn't fail because of an
+		// auth blip on a sibling endpoint.
+		return ""
+	}
+	for _, mem := range memberships {
+		if mem.TeamSlug == identifier {
+			return ""
+		}
+	}
+	return "(invalid — not a member; run `justtunnel context use personal` to clear)"
+}
+
+// looksLikeULID reports whether identifier has the shape of a Crockford
+// base32 ULID (26 uppercase alphanumerics, no I/L/O/U). The CLI accepts
+// either a slug or a ULID in `team:<id-or-slug>` form (see
+// config.ValidateContext); the memberships endpoint only returns slugs, so
+// ULID-shaped identifiers cannot be cross-checked and should not be flagged.
+func looksLikeULID(identifier string) bool {
+	if len(identifier) != 26 {
+		return false
+	}
+	for _, character := range identifier {
+		isUpper := character >= 'A' && character <= 'Z'
+		isDigit := character >= '0' && character <= '9'
+		if !isUpper && !isDigit {
+			return false
+		}
+	}
+	return true
 }
 
 // fetchMembershipsHTTP calls GET /api/memberships on the server. If the server

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -29,12 +30,75 @@ type membership struct {
 
 // membershipFetcher fetches team memberships for the authenticated user.
 // Production wiring uses fetchMembershipsHTTP; tests inject stubs.
-// Returns (memberships, supported). supported=false means the server does
-// not yet implement the endpoint and the CLI should fall back to a hint.
-type membershipFetcher func(client *http.Client, baseURL, authToken string) ([]membership, bool, error)
+// Returns (memberships, supported, definitelyNotMember, err). supported=false
+// means the server does not yet implement the endpoint and the CLI should
+// fall back to a hint. definitelyNotMember=true means the server returned 403
+// (e.g. token revoked, team membership no longer valid) — callers should
+// treat this as a definitive "not a member" signal rather than failing open.
+type membershipFetcher func(client *http.Client, baseURL, authToken string) ([]membership, bool, bool, error)
 
 // fetchMemberships is the package-level fetcher; tests may swap it.
 var fetchMemberships membershipFetcher = fetchMembershipsHTTP
+
+// membershipCache provides a process-lifetime in-memory cache of the
+// /api/memberships response, keyed on (baseURL, authToken). It exists to
+// avoid doubling latency on every worker subcommand: loadWorkerEnv calls
+// stalenessAnnotation which fetches memberships, then the actual REST call
+// runs immediately afterwards. A 30s TTL means a token rotation or
+// membership revocation is reflected within a single trivial wait.
+type membershipCacheEntry struct {
+	memberships         []membership
+	supported           bool
+	definitelyNotMember bool
+	fetchedAt           time.Time
+}
+
+var (
+	membershipCacheMu  sync.Mutex
+	membershipCacheMap = map[string]membershipCacheEntry{}
+)
+
+// membershipCacheTTL is the cache window. Declared as a var so tests can
+// shrink it; at runtime 30s is short enough that revocations are reflected
+// quickly while still de-duplicating the back-to-back calls inside a single
+// worker subcommand invocation.
+var membershipCacheTTL = 30 * time.Second
+
+// fetchMembershipsCached wraps fetchMemberships with the (baseURL,authToken)
+// keyed cache. Tests that inject fetchMemberships still see every call (the
+// fetcher swap happens above this layer when tests assign to
+// fetchMemberships); production code paths benefit from de-duplication.
+// Errors are NOT cached so a transient 5xx doesn't poison the next call.
+func fetchMembershipsCached(client *http.Client, baseURL, authToken string) ([]membership, bool, bool, error) {
+	cacheKey := baseURL + "\x00" + authToken
+	membershipCacheMu.Lock()
+	entry, ok := membershipCacheMap[cacheKey]
+	membershipCacheMu.Unlock()
+	if ok && time.Since(entry.fetchedAt) < membershipCacheTTL {
+		return entry.memberships, entry.supported, entry.definitelyNotMember, nil
+	}
+	memberships, supported, definitelyNotMember, err := fetchMemberships(client, baseURL, authToken)
+	if err != nil {
+		return memberships, supported, definitelyNotMember, err
+	}
+	membershipCacheMu.Lock()
+	membershipCacheMap[cacheKey] = membershipCacheEntry{
+		memberships:         memberships,
+		supported:           supported,
+		definitelyNotMember: definitelyNotMember,
+		fetchedAt:           time.Now(),
+	}
+	membershipCacheMu.Unlock()
+	return memberships, supported, definitelyNotMember, nil
+}
+
+// resetMembershipCache clears the cache. Tests call this between cases so a
+// stub change in one test doesn't leak into the next.
+func resetMembershipCache() {
+	membershipCacheMu.Lock()
+	membershipCacheMap = map[string]membershipCacheEntry{}
+	membershipCacheMu.Unlock()
+}
 
 // activeContextPusher syncs the user's active context to the server so the
 // WS worker handshake can resolve the team without requiring team_slug on
@@ -117,13 +181,13 @@ func runContextList(cmd *cobra.Command, args []string) error {
 	// Pass nil so fetchMembershipsHTTP builds its own client with a 10s
 	// timeout. Passing http.DefaultClient would skip the timeout and risk a
 	// hang against an unresponsive server.
-	memberships, supported, err := fetchMemberships(nil, baseURL, cfg.AuthToken)
+	memberships, supported, _, err := fetchMembershipsCached(nil, baseURL, cfg.AuthToken)
 	if err != nil {
 		// Network/timeout errors degrade gracefully (warning to stderr) so
 		// the user still sees their personal context. Other non-2xx
 		// responses (401/403/500/...) are loud failures with non-zero exit.
 		if isNetworkError(err) {
-			fmt.Fprintf(os.Stderr, "warning: could not list team memberships: %v\n", err)
+			fmt.Fprintf(os.Stderr, "warning: could not reach server: %v\n", err)
 			return nil
 		}
 		return fmt.Errorf("list team memberships: %w", err)
@@ -155,13 +219,22 @@ func runContextList(cmd *cobra.Command, args []string) error {
 // failure (DNS, connection refused, timeout) as opposed to a structured HTTP
 // error response. Network failures degrade gracefully; structured errors
 // surface to the user.
+//
+// We unwrap *url.Error to inspect the inner cause: a TLS handshake or
+// redirect-loop failure is wrapped in url.Error too, but it is NOT a
+// transient connectivity issue and should surface differently. Only inner
+// net.Error (timeout, refused, DNS) qualifies as "network".
 func isNetworkError(err error) bool {
 	if err == nil {
 		return false
 	}
 	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
-		return true
+	if errors.As(err, &urlErr) && urlErr.Err != nil {
+		var inner net.Error
+		if errors.As(urlErr.Err, &inner) {
+			return true
+		}
+		return false
 	}
 	var netErr net.Error
 	if errors.As(err, &netErr) {
@@ -189,39 +262,50 @@ func runContextUse(cmd *cobra.Command, args []string) error {
 	// We only validate when the user is authenticated AND the server
 	// supports the memberships endpoint. If it doesn't, fall through to
 	// the previous behavior so older servers still work.
-	if cfg.AuthToken != "" && strings.HasPrefix(name, config.TeamContextPrefix) {
-		baseURL, parseErr := apiBaseURL(cfg.ServerURL)
-		if parseErr == nil {
-			memberships, supported, fetchErr := fetchMemberships(nil, baseURL, cfg.AuthToken)
-			switch {
-			case fetchErr != nil && isNetworkError(fetchErr):
-				// Offline / unreachable server: warn and proceed so the
-				// user can keep working without connectivity.
-				fmt.Fprintf(os.Stderr,
-					"warning: could not verify team membership (offline?): %v\n", fetchErr)
-			case fetchErr != nil:
-				// Structured server error (4xx/5xx other than 404):
-				// surface so the user knows validation failed.
-				return fmt.Errorf("verify team membership: %w", fetchErr)
-			case supported:
-				slug := strings.TrimPrefix(name, config.TeamContextPrefix)
-				found := false
-				for _, mem := range memberships {
-					if mem.TeamSlug == slug {
-						found = true
-						break
-					}
-				}
-				if !found {
-					return display.InputError(fmt.Sprintf(
-						"you are not a member of %s — run `justtunnel context list` to see available teams",
-						name,
-					))
+	//
+	// offlineDetected is set when the validation step already determined
+	// the server is unreachable. The downstream best-effort push then
+	// skips its own attempt to avoid emitting a second redundant warning.
+	offlineDetected := false
+	baseURL, parseErr := apiBaseURL(cfg.ServerURL)
+	if cfg.AuthToken != "" && strings.HasPrefix(name, config.TeamContextPrefix) && parseErr == nil {
+		memberships, supported, definitelyNotMember, fetchErr := fetchMembershipsCached(nil, baseURL, cfg.AuthToken)
+		switch {
+		case fetchErr != nil && isNetworkError(fetchErr):
+			// Offline / unreachable server: warn and proceed so the
+			// user can keep working without connectivity.
+			offlineDetected = true
+			fmt.Fprintf(os.Stderr,
+				"warning: could not reach server to verify team membership: %v\n", fetchErr)
+		case fetchErr != nil:
+			// Structured server error (4xx/5xx other than 404):
+			// surface so the user knows validation failed.
+			return fmt.Errorf("verify team membership: %w", fetchErr)
+		case definitelyNotMember:
+			// 403 from /api/memberships: token is valid but the server
+			// considers the user not a member (e.g. revoked).
+			return display.InputError(fmt.Sprintf(
+				"server rejected your team membership for %s — re-run `justtunnel auth` or `justtunnel context use personal`",
+				name,
+			))
+		case supported:
+			slug := strings.TrimPrefix(name, config.TeamContextPrefix)
+			found := false
+			for _, mem := range memberships {
+				if mem.TeamSlug == slug {
+					found = true
+					break
 				}
 			}
-			// supported=false (older server): fall through; we cannot
-			// verify and forcing a hard error would break compatibility.
+			if !found {
+				return display.InputError(fmt.Sprintf(
+					"you are not a member of %s — run `justtunnel context list` to see available teams",
+					name,
+				))
+			}
 		}
+		// supported=false (older server): fall through; we cannot
+		// verify and forcing a hard error would break compatibility.
 	}
 
 	if err := config.SetCurrentContext(cfg, name); err != nil {
@@ -235,9 +319,12 @@ func runContextUse(cmd *cobra.Command, args []string) error {
 	// source of truth — push failures degrade to a stderr warning so the
 	// user can keep working offline. See justtunnel-cli#44.
 	if cfg.AuthToken != "" {
-		baseURL, parseErr := apiBaseURL(cfg.ServerURL)
 		if parseErr != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not sync context to server: %v\n", parseErr)
+			return nil
+		}
+		if offlineDetected {
+			// Already warned about unreachability above; don't double-warn.
 			return nil
 		}
 		if pushErr := pushActiveContext(nil, baseURL, cfg.AuthToken, name); pushErr != nil {
@@ -261,53 +348,64 @@ func runContextShow(cmd *cobra.Command, args []string) error {
 	// personal`. Failures to verify (offline, unsupported endpoint, network)
 	// fall through silently so `context show` keeps working without a
 	// reachable server.
-	if note := stalenessAnnotation(cfg, active); note != "" {
-		fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n", active, note)
+	//
+	// Compute the REST base URL once and pass it down so stalenessAnnotation
+	// doesn't repeat the work the caller already did.
+	baseURL, baseURLErr := apiBaseURL(cfg.ServerURL)
+	if baseURLErr != nil {
+		fmt.Fprintln(cmd.OutOrStdout(), active)
 		return nil
 	}
-
+	annotation, stale := stalenessAnnotation(cfg, baseURL, active)
+	if stale {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n", active, annotation)
+		return nil
+	}
 	fmt.Fprintln(cmd.OutOrStdout(), active)
 	return nil
 }
 
-// stalenessAnnotation returns a parenthesized note when the active context
-// references a team the user is not a member of, or "" when the context is
-// either valid, personal, or cannot be verified (offline, older server,
-// ULID-shaped identifier we cannot resolve via the slug-keyed memberships
-// endpoint). Callers append the annotation to the printed context.
-func stalenessAnnotation(cfg *config.Config, active string) string {
+// stalenessAnnotation returns (annotation, stale). When stale=true the
+// caller should append annotation to the printed context. stale=false
+// means the context is either valid, personal, or cannot be verified
+// (offline, older server, ULID-shaped identifier we cannot resolve via
+// the slug-keyed memberships endpoint).
+//
+// Callers compute the REST baseURL once and pass it in to avoid two
+// successive apiBaseURL calls.
+func stalenessAnnotation(cfg *config.Config, baseURL, active string) (string, bool) {
 	if cfg == nil || cfg.AuthToken == "" {
-		return ""
+		return "", false
 	}
 	if !strings.HasPrefix(active, config.TeamContextPrefix) {
-		return ""
+		return "", false
 	}
 	identifier := strings.TrimPrefix(active, config.TeamContextPrefix)
 	if identifier == "" || looksLikeULID(identifier) {
 		// ULIDs are addressed by Team.ID, not slug — the memberships
 		// endpoint returns slugs, so we cannot prove staleness here.
 		// Fail open rather than annotate a valid ULID-shaped context.
-		return ""
+		return "", false
 	}
 
-	baseURL, err := apiBaseURL(cfg.ServerURL)
-	if err != nil {
-		return ""
+	memberships, supported, definitelyNotMember, err := fetchMembershipsCached(nil, baseURL, cfg.AuthToken)
+	if definitelyNotMember {
+		// 403 from /api/memberships: server says the token holder isn't a
+		// member of any team. Treat the active team context as stale.
+		return "(invalid — not a member; run `justtunnel context use personal` to clear)", true
 	}
-	memberships, supported, err := fetchMemberships(nil, baseURL, cfg.AuthToken)
 	if err != nil || !supported {
-		// Unsupported endpoint or any fetch error: fail open. Loud server
-		// errors (4xx/5xx) are intentionally swallowed here — `context
+		// Unsupported endpoint, network blip, or 5xx: fail open. `context
 		// show` is a read-only diagnostic and shouldn't fail because of an
 		// auth blip on a sibling endpoint.
-		return ""
+		return "", false
 	}
 	for _, mem := range memberships {
 		if mem.TeamSlug == identifier {
-			return ""
+			return "", false
 		}
 	}
-	return "(invalid — not a member; run `justtunnel context use personal` to clear)"
+	return "(invalid — not a member; run `justtunnel context use personal` to clear)", true
 }
 
 // looksLikeULID reports whether identifier has the shape of a Crockford
@@ -325,46 +423,61 @@ func looksLikeULID(identifier string) bool {
 		if !isUpper && !isDigit {
 			return false
 		}
+		// Crockford base32 explicitly excludes I, L, O, U to avoid
+		// visual ambiguity with 1, 1, 0, and V respectively. Reject
+		// any identifier that contains one of those letters even if
+		// the rest of the alphanumeric check would have accepted it.
+		if character == 'I' || character == 'L' || character == 'O' || character == 'U' {
+			return false
+		}
 	}
 	return true
 }
 
 // fetchMembershipsHTTP calls GET /api/memberships on the server. If the server
 // returns 404, it reports supported=false so the caller can degrade gracefully.
-func fetchMembershipsHTTP(client *http.Client, baseURL, authToken string) ([]membership, bool, error) {
+// If the server returns 403, it reports definitelyNotMember=true so callers
+// can treat that as a definitive "not a member" signal (vs a transient 5xx).
+func fetchMembershipsHTTP(client *http.Client, baseURL, authToken string) ([]membership, bool, bool, error) {
 	if client == nil {
 		client = &http.Client{Timeout: 10 * time.Second}
 	}
 	req, err := http.NewRequest(http.MethodGet, baseURL+"/api/memberships", nil)
 	if err != nil {
-		return nil, false, fmt.Errorf("build request: %w", err)
+		return nil, false, false, fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Authorization", config.AuthHeaderPrefix+authToken)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, false, fmt.Errorf("request: %w", err)
+		return nil, false, false, fmt.Errorf("request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, false, nil
+		return nil, false, false, nil
+	}
+	if resp.StatusCode == http.StatusForbidden {
+		// 403 means the token is valid in shape but the server says the
+		// user isn't a member of any team. Surface the signal so callers
+		// can annotate context as stale rather than failing open.
+		return nil, true, true, nil
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// Bound the read so a malicious or misconfigured server cannot OOM
 		// the CLI by streaming an enormous error body.
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, true, fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+		return nil, true, false, fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
 	}
 
 	var payload struct {
 		Memberships []membership `json:"memberships"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return nil, true, fmt.Errorf("decode response: %w", err)
+		return nil, true, false, fmt.Errorf("decode response: %w", err)
 	}
-	return payload.Memberships, true, nil
+	return payload.Memberships, true, false, nil
 }
 
 // pushActiveContextHTTP POSTs the active context name to the server so the

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -456,6 +456,156 @@ func TestContextUseAcceptsMemberTeam(t *testing.T) {
 	}
 }
 
+// TestContextShowAnnotatesStaleSlug verifies F-21: when the active context
+// is a team slug the user is no longer a member of (e.g. team was deleted
+// or membership revoked while a stale slug lingered in local config),
+// `context show` prints the slug with an "(invalid — ...)" annotation
+// rather than emitting it verbatim. The local config is left untouched so
+// the user can clear it explicitly with `context use personal`.
+func TestContextShowAnnotatesStaleSlug(t *testing.T) {
+	stubServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/memberships" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Write([]byte(`{"memberships":[{"team_slug":"acme"}]}`))
+	}))
+	defer stubServer.Close()
+
+	resetContextState(t, &config.Config{
+		AuthToken:      "tok",
+		ServerURL:      httpToWS(stubServer.URL) + "/ws",
+		CurrentContext: "team:does-not-exist-xyz",
+	})
+
+	out, err := runCmd(t, "context", "show")
+	if err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	if !strings.Contains(out, "team:does-not-exist-xyz") {
+		t.Errorf("output should still include the stale slug for visibility, got: %q", out)
+	}
+	if !strings.Contains(out, "invalid") {
+		t.Errorf("output should annotate the slug as invalid, got: %q", out)
+	}
+	if !strings.Contains(out, "context use personal") {
+		t.Errorf("output should hint at the recovery command, got: %q", out)
+	}
+
+	// Read-path must not mutate config: a subsequent `context use personal`
+	// is the only way to clear the stale value.
+	loaded, loadErr := config.Load(cfgFile)
+	if loadErr != nil {
+		t.Fatalf("load: %v", loadErr)
+	}
+	if loaded.CurrentContext != "team:does-not-exist-xyz" {
+		t.Errorf("show must not mutate config; got CurrentContext=%q", loaded.CurrentContext)
+	}
+}
+
+// TestContextShowDoesNotAnnotateValidTeam verifies the no-false-positive
+// case: when the active slug IS in the membership list, `context show`
+// prints it verbatim with no annotation.
+func TestContextShowDoesNotAnnotateValidTeam(t *testing.T) {
+	stubServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/memberships" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Write([]byte(`{"memberships":[{"team_slug":"acme"}]}`))
+	}))
+	defer stubServer.Close()
+
+	resetContextState(t, &config.Config{
+		AuthToken:      "tok",
+		ServerURL:      httpToWS(stubServer.URL) + "/ws",
+		CurrentContext: "team:acme",
+	})
+
+	out, err := runCmd(t, "context", "show")
+	if err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	if strings.TrimSpace(out) != "team:acme" {
+		t.Errorf("valid team should print without annotation; got %q", strings.TrimSpace(out))
+	}
+}
+
+// TestContextShowFailsOpenWhenServerUnsupported verifies that older servers
+// (no /api/memberships route) do not cause `context show` to annotate
+// every team context as invalid. The CLI cannot prove staleness, so it
+// must emit the slug verbatim.
+func TestContextShowFailsOpenWhenServerUnsupported(t *testing.T) {
+	stubServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		http.NotFound(writer, request)
+	}))
+	defer stubServer.Close()
+
+	resetContextState(t, &config.Config{
+		AuthToken:      "tok",
+		ServerURL:      httpToWS(stubServer.URL) + "/ws",
+		CurrentContext: "team:acme",
+	})
+
+	out, err := runCmd(t, "context", "show")
+	if err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	if strings.TrimSpace(out) != "team:acme" {
+		t.Errorf("unsupported server must fail open; got %q", strings.TrimSpace(out))
+	}
+}
+
+// TestContextShowFailsOpenWhenLoggedOut verifies that without an auth token
+// the CLI never annotates — there is no way to verify, and a logged-out
+// user shouldn't get a confusing warning on a read-only command.
+func TestContextShowFailsOpenWhenLoggedOut(t *testing.T) {
+	resetContextState(t, &config.Config{
+		ServerURL:      "wss://api.example.com/ws",
+		CurrentContext: "team:acme",
+	})
+
+	out, err := runCmd(t, "context", "show")
+	if err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	if strings.TrimSpace(out) != "team:acme" {
+		t.Errorf("logged-out show must not annotate; got %q", strings.TrimSpace(out))
+	}
+}
+
+// TestContextShowFailsOpenForULIDIdentifier verifies the ULID escape
+// hatch: the memberships endpoint returns slugs, so a ULID-shaped
+// identifier cannot be cross-checked and must NOT be flagged as stale.
+func TestContextShowFailsOpenForULIDIdentifier(t *testing.T) {
+	stubServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/memberships" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Write([]byte(`{"memberships":[{"team_slug":"acme"}]}`))
+	}))
+	defer stubServer.Close()
+
+	const ulid = "01KQTJBVA6REFPMKT8MPKX8Z9N"
+	resetContextState(t, &config.Config{
+		AuthToken:      "tok",
+		ServerURL:      httpToWS(stubServer.URL) + "/ws",
+		CurrentContext: "team:" + ulid,
+	})
+
+	out, err := runCmd(t, "context", "show")
+	if err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	if strings.TrimSpace(out) != "team:"+ulid {
+		t.Errorf("ULID-shaped id must not be annotated; got %q", strings.TrimSpace(out))
+	}
+}
+
 // TestContextUseTolerates404FromOlderServer verifies older servers (no
 // /api/memberships route) still allow `context use` so the CLI doesn't
 // break compatibility. The previous behavior is preserved when supported

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/justtunnel/justtunnel-cli/internal/config"
@@ -24,7 +25,8 @@ func resetContextState(t *testing.T, cfg *config.Config) string {
 	config.SetConfigPath(path)
 	cfgFile = path
 	contextOverride = ""
-	t.Cleanup(func() { contextOverride = "" })
+	resetMembershipCache()
+	t.Cleanup(func() { contextOverride = ""; resetMembershipCache() })
 
 	if cfg == nil {
 		cfg = &config.Config{ServerURL: "wss://api.example.com/ws"}
@@ -147,6 +149,16 @@ func TestContextUsePushesToServer(t *testing.T) {
 		AuthToken: "tok_test",
 	})
 
+	// Stub the membership fetcher so the validation step doesn't actually
+	// hit the unreachable api.example.com (which would otherwise mark the
+	// command as "offline" and skip the push entirely).
+	previousFetcher := fetchMemberships
+	t.Cleanup(func() { fetchMemberships = previousFetcher; resetMembershipCache() })
+	fetchMemberships = func(client *http.Client, baseURL, authToken string) ([]membership, bool, bool, error) {
+		return []membership{{TeamSlug: "acme"}}, true, false, nil
+	}
+	resetMembershipCache()
+
 	previousPusher := pushActiveContext
 	t.Cleanup(func() { pushActiveContext = previousPusher })
 
@@ -204,7 +216,7 @@ func TestContextUseSkipsServerSyncWhenLoggedOut(t *testing.T) {
 	}
 }
 
-// TestContextUseTolerates404FromOlderServer verifies that pushActiveContextHTTP
+// TestPushActiveContextHTTP_TolerantOf404 verifies that pushActiveContextHTTP
 // returns nil when the server returns 404, so older servers without the
 // route don't surface a confusing warning.
 func TestPushActiveContextHTTP_TolerantOf404(t *testing.T) {
@@ -357,7 +369,7 @@ func TestFetchMembershipsHTTPError(t *testing.T) {
 	}))
 	defer stubServer.Close()
 
-	_, supported, err := fetchMembershipsHTTP(stubServer.Client(), stubServer.URL, "tok")
+	_, supported, _, err := fetchMembershipsHTTP(stubServer.Client(), stubServer.URL, "tok")
 	if err == nil {
 		t.Fatal("expected error on 500, got nil")
 	}
@@ -372,15 +384,44 @@ func TestFetchMembershipsHTTP404(t *testing.T) {
 	}))
 	defer stubServer.Close()
 
-	memberships, supported, err := fetchMembershipsHTTP(stubServer.Client(), stubServer.URL, "tok")
+	memberships, supported, definitelyNotMember, err := fetchMembershipsHTTP(stubServer.Client(), stubServer.URL, "tok")
 	if err != nil {
 		t.Fatalf("404 should not surface as error: %v", err)
 	}
 	if supported {
 		t.Errorf("supported should be false on 404")
 	}
+	if definitelyNotMember {
+		t.Errorf("definitelyNotMember should be false on 404")
+	}
 	if memberships != nil {
 		t.Errorf("memberships should be nil on 404, got %v", memberships)
+	}
+}
+
+// TestFetchMembershipsHTTP403 verifies the tri-state extension: a 403 must
+// be reported as definitelyNotMember=true rather than as an opaque error,
+// so callers (stalenessAnnotation, runContextUse) can treat the response
+// as a definitive "not a member" signal.
+func TestFetchMembershipsHTTP403(t *testing.T) {
+	stubServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusForbidden)
+		writer.Write([]byte(`{"error":"not a member"}`))
+	}))
+	defer stubServer.Close()
+
+	memberships, supported, definitelyNotMember, err := fetchMembershipsHTTP(stubServer.Client(), stubServer.URL, "tok")
+	if err != nil {
+		t.Fatalf("403 should not surface as error: %v", err)
+	}
+	if !supported {
+		t.Errorf("supported should be true on 403")
+	}
+	if !definitelyNotMember {
+		t.Errorf("definitelyNotMember should be true on 403")
+	}
+	if memberships != nil {
+		t.Errorf("memberships should be nil on 403, got %v", memberships)
 	}
 }
 
@@ -467,6 +508,11 @@ func TestContextShowAnnotatesStaleSlug(t *testing.T) {
 		if request.URL.Path != "/api/memberships" {
 			http.NotFound(writer, request)
 			return
+		}
+		// C-7: assert the CLI is sending the right Authorization header
+		// rather than treating the stub as a black box.
+		if got := request.Header.Get("Authorization"); got != "Bearer tok" {
+			t.Errorf("Authorization header: got %q, want %q", got, "Bearer tok")
 		}
 		writer.Header().Set("Content-Type", "application/json")
 		writer.Write([]byte(`{"memberships":[{"team_slug":"acme"}]}`))
@@ -624,5 +670,159 @@ func TestContextUseTolerates404FromOlderServer(t *testing.T) {
 
 	if _, err := runCmd(t, "context", "use", "team:acme"); err != nil {
 		t.Fatalf("404 from /api/memberships should not block context use: %v", err)
+	}
+}
+
+// TestLooksLikeULID_ExcludesCrockfordInvalid verifies that I, L, O, and U
+// (which Crockford base32 explicitly excludes to avoid visual ambiguity
+// with 1, 1, 0, V) are rejected in any position. Without this, the
+// stalenessAnnotation ULID escape hatch silently treats invalid
+// identifiers as ULID-shaped and skips the membership cross-check.
+func TestLooksLikeULID_ExcludesCrockfordInvalid(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{"contains I (start)", "I1KQTJBVA6REFPMKT8MPKX8Z9N"},
+		{"contains I (mid)", "01KQTJBVA6IEFPMKT8MPKX8Z9N"},
+		{"contains L (mid)", "01KQTJBVA6REFPMKT8LPKX8Z9N"},
+		{"contains O (start)", "O1KQTJBVA6REFPMKT8MPKX8Z9N"},
+		{"contains U (mid)", "01KQTJBVA6REFPMKT8UPKX8Z9N"},
+		{"contains O (end)", "01KQTJBVA6REFPMKT8MPKX8Z9O"},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			if len(testCase.id) != 26 {
+				t.Fatalf("test setup error: id length = %d, want 26", len(testCase.id))
+			}
+			if looksLikeULID(testCase.id) {
+				t.Errorf("looksLikeULID(%q) = true, want false (contains Crockford-invalid char)", testCase.id)
+			}
+		})
+	}
+}
+
+// TestLooksLikeULID_AcceptsValidCrockford complements the negative cases:
+// a real ULID using only Crockford-valid characters must still pass.
+func TestLooksLikeULID_AcceptsValidCrockford(t *testing.T) {
+	const validULID = "01KQTJBVA6REFPMKT8MPKX8Z9N"
+	if len(validULID) != 26 {
+		t.Fatalf("test setup error: id length = %d, want 26", len(validULID))
+	}
+	if !looksLikeULID(validULID) {
+		t.Errorf("looksLikeULID(%q) = false, want true (valid Crockford ULID)", validULID)
+	}
+}
+
+// TestStalenessAnnotationCachesMembershipFetch verifies C-3: back-to-back
+// staleness checks (e.g. context show then a worker subcommand within the
+// 30s TTL) reuse the cached /api/memberships response instead of hitting
+// the server twice.
+func TestStalenessAnnotationCachesMembershipFetch(t *testing.T) {
+	var requestCount int32
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/memberships" {
+			http.NotFound(writer, request)
+			return
+		}
+		atomic.AddInt32(&requestCount, 1)
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Write([]byte(`{"memberships":[{"team_slug":"acme"}]}`))
+	}))
+	defer stub.Close()
+
+	resetContextState(t, &config.Config{
+		AuthToken: "tok",
+		ServerURL: httpToWS(stub.URL) + "/ws",
+	})
+
+	// Two successive calls to stalenessAnnotation in quick succession.
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	baseURL, err := apiBaseURL(cfg.ServerURL)
+	if err != nil {
+		t.Fatalf("apiBaseURL: %v", err)
+	}
+	if _, stale := stalenessAnnotation(cfg, baseURL, "team:acme"); stale {
+		t.Fatalf("first call: should not be stale for valid membership")
+	}
+	if _, stale := stalenessAnnotation(cfg, baseURL, "team:acme"); stale {
+		t.Fatalf("second call: should not be stale for valid membership")
+	}
+	if got := atomic.LoadInt32(&requestCount); got != 1 {
+		t.Errorf("expected 1 HTTP request to /api/memberships (cached on second call); got %d", got)
+	}
+}
+
+// TestStalenessAnnotation403MarksStale verifies C-4: a 403 from
+// /api/memberships is treated as "definitely not a member" rather than
+// failing open. This catches the case where membership was revoked
+// server-side while a stale slug lingered locally.
+func TestStalenessAnnotation403MarksStale(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/memberships" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.WriteHeader(http.StatusForbidden)
+		writer.Write([]byte(`{"error":"not a member"}`))
+	}))
+	defer stub.Close()
+
+	resetContextState(t, &config.Config{
+		AuthToken:      "tok",
+		ServerURL:      httpToWS(stub.URL) + "/ws",
+		CurrentContext: "team:acme",
+	})
+
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	baseURL, err := apiBaseURL(cfg.ServerURL)
+	if err != nil {
+		t.Fatalf("apiBaseURL: %v", err)
+	}
+	annotation, stale := stalenessAnnotation(cfg, baseURL, "team:acme")
+	if !stale {
+		t.Fatalf("expected stale=true on 403, got false (annotation=%q)", annotation)
+	}
+	if !strings.Contains(annotation, "not a member") {
+		t.Errorf("annotation should mention not-a-member; got %q", annotation)
+	}
+}
+
+// TestStalenessAnnotationFailsOpenOn5xx verifies the C-4 contract: a
+// transient 5xx must NOT be treated as definitive. The CLI fails open so
+// `context show` keeps working through a brief server blip.
+func TestStalenessAnnotationFailsOpenOn5xx(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/memberships" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.WriteHeader(http.StatusInternalServerError)
+		writer.Write([]byte(`{"error":"db down"}`))
+	}))
+	defer stub.Close()
+
+	resetContextState(t, &config.Config{
+		AuthToken:      "tok",
+		ServerURL:      httpToWS(stub.URL) + "/ws",
+		CurrentContext: "team:acme",
+	})
+
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	baseURL, err := apiBaseURL(cfg.ServerURL)
+	if err != nil {
+		t.Fatalf("apiBaseURL: %v", err)
+	}
+	if _, stale := stalenessAnnotation(cfg, baseURL, "team:acme"); stale {
+		t.Errorf("5xx must fail open, not annotate as stale")
 	}
 }

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -111,16 +112,41 @@ func loadWorkerEnv() (cfg *config.Config, teamID, ctxName, baseURL string, err e
 	// F-21: refuse early when the active team context is a stale slug the
 	// user is no longer a member of. Without this check, every worker
 	// subcommand fails with an opaque 403/404 from the team-scoped REST
-	// route. stalenessAnnotation returns "" when verification is not
-	// possible (offline, older server, ULID-shaped identifier), so we
+	// route. stalenessAnnotation returns stale=false when verification is
+	// not possible (offline, older server, ULID-shaped identifier), so we
 	// preserve compatibility and offline workflows.
-	if stalenessAnnotation(cfg, ctxName) != "" {
+	if _, stale := stalenessAnnotation(cfg, baseURL, ctxName); stale {
 		return nil, "", "", "", display.InputError(fmt.Sprintf(
-			"active context %s is invalid — you are not a member of that team. Run `justtunnel context use personal` (or `context use team:<slug>` for a current team) and retry.",
+			"active context %s is no longer valid — run `justtunnel context use personal` to clear",
 			ctxName,
 		))
 	}
 	return cfg, teamID, ctxName, baseURL, nil
+}
+
+// mapForbiddenError converts a 403 response from a team-scoped REST endpoint
+// into a typed display.InputError with an actionable, server-shape-aware
+// message. The server returns {"error":"..."} bodies; we detect a few known
+// phrasings ("not a member", "admin", "only team admins") and fall back to
+// a generic "forbidden: <body>" otherwise. Keeps the user from staring at
+// an opaque "server returned 403" mid-flight after membership pre-check
+// already passed (e.g. revoked between the two calls, or the action is
+// admin-gated like ?include=quarantined).
+func mapForbiddenError(body []byte) error {
+	serverMsg := extractServerError(body)
+	lowerMsg := strings.ToLower(serverMsg)
+	switch {
+	case strings.Contains(lowerMsg, "not a member"):
+		return display.InputError(
+			"your team membership is no longer valid — run `justtunnel context use personal` and retry",
+		)
+	case strings.Contains(lowerMsg, "only team admins") || strings.Contains(lowerMsg, "admin"):
+		return display.InputError(
+			"this action requires team admin role; re-run without admin-only options",
+		)
+	default:
+		return display.InputError(fmt.Sprintf("forbidden: %s", serverMsg))
+	}
 }
 
 // httpDo performs an authenticated request and returns body + status. The
@@ -181,16 +207,21 @@ func extractServerError(body []byte) string {
 }
 
 // postWorker calls POST /api/teams/{teamID}/workers and returns the parsed
-// worker. Non-2xx responses surface as errors with the server's message.
+// worker. Non-2xx responses surface as errors with the server's message;
+// 403 specifically routes through mapForbiddenError so the user gets a
+// friendly recovery hint rather than "server returned 403".
 func postWorker(ctx context.Context, baseURL, authToken, teamID, name string) (*workerAPI, error) {
 	// json.Marshal on a map[string]string with a literal key cannot fail
 	// (no unsupported types possible). Explicit `_ =` documents the
 	// intentional discard.
 	body, _ := json.Marshal(map[string]string{"name": name})
-	url := baseURL + "/api/teams/" + teamID + "/workers"
-	status, raw, err := httpDo(ctx, http.MethodPost, url, authToken, bytes.NewReader(body))
+	requestURL := baseURL + "/api/teams/" + teamID + "/workers"
+	status, raw, err := httpDo(ctx, http.MethodPost, requestURL, authToken, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
+	}
+	if status == http.StatusForbidden {
+		return nil, mapForbiddenError(raw)
 	}
 	if status < 200 || status >= 300 {
 		return nil, fmt.Errorf("server returned %d: %s", status, extractServerError(raw))
@@ -202,28 +233,40 @@ func postWorker(ctx context.Context, baseURL, authToken, teamID, name string) (*
 	return &worker, nil
 }
 
-// fetchWorkers calls GET /api/teams/{teamID}/workers. The default response
-// excludes workers in `retired_quarantined` (the 30-day soft-delete window
-// after `worker rm --delete-on-server`).
-func fetchWorkers(ctx context.Context, baseURL, authToken, teamID string) ([]workerAPI, error) {
-	return fetchWorkersWithOptions(ctx, baseURL, authToken, teamID, false)
+// FetchWorkersOptions controls optional behavior of fetchWorkers. The
+// zero-value is the safe default (live workers only); set
+// IncludeQuarantined to additionally surface soft-deleted rows. Callers
+// pass empty options for the default path (status, install, uninstall,
+// rm) so quota-counting consumers keep matching the dashboard view.
+type FetchWorkersOptions struct {
+	// IncludeQuarantined sends `?include=quarantined` so the server
+	// returns workers in retired_quarantined alongside live ones — used by
+	// `worker list --all` (justtunnel-cli#50, justtunnel-server F-20).
+	// Note: the server admin-gates this on some plans; non-admin callers
+	// receive a 403 which mapForbiddenError translates.
+	IncludeQuarantined bool
 }
 
-// fetchWorkersWithOptions is fetchWorkers with an explicit
-// includeQuarantined flag. When true, the request adds
-// `?include=quarantined` so the server returns soft-deleted workers
-// alongside live ones — used by `worker list --all` (justtunnel-cli#50,
-// justtunnel-server F-20). The default path goes through fetchWorkers so
-// quota-counting consumers (status, install, uninstall, rm) keep matching
-// the dashboard view.
-func fetchWorkersWithOptions(ctx context.Context, baseURL, authToken, teamID string, includeQuarantined bool) ([]workerAPI, error) {
-	url := baseURL + "/api/teams/" + teamID + "/workers"
-	if includeQuarantined {
-		url += "?include=quarantined"
+// fetchWorkers calls GET /api/teams/{teamID}/workers. opts.IncludeQuarantined
+// adds `?include=quarantined`. 403 responses route through mapForbiddenError
+// so admin-gated server policies surface as actionable errors rather than
+// "server returned 403".
+func fetchWorkers(ctx context.Context, baseURL, authToken, teamID string, opts FetchWorkersOptions) ([]workerAPI, error) {
+	requestURL := baseURL + "/api/teams/" + teamID + "/workers"
+	if opts.IncludeQuarantined {
+		// Use url.Values rather than bare string concatenation so adding
+		// future params (e.g. ?status=...) doesn't require rewriting this
+		// callsite for proper '&' joining and percent-encoding.
+		queryValues := url.Values{}
+		queryValues.Set("include", "quarantined")
+		requestURL += "?" + queryValues.Encode()
 	}
-	status, raw, err := httpDo(ctx, http.MethodGet, url, authToken, nil)
+	status, raw, err := httpDo(ctx, http.MethodGet, requestURL, authToken, nil)
 	if err != nil {
 		return nil, err
+	}
+	if status == http.StatusForbidden {
+		return nil, mapForbiddenError(raw)
 	}
 	if status < 200 || status >= 300 {
 		return nil, fmt.Errorf("server returned %d: %s", status, extractServerError(raw))
@@ -237,15 +280,19 @@ func fetchWorkersWithOptions(ctx context.Context, baseURL, authToken, teamID str
 
 // deleteWorker calls DELETE /api/teams/{teamID}/workers/{workerID}.
 // Returns (notFound=true, nil) on 404 so the caller can treat it as
-// already-deleted and continue local cleanup.
+// already-deleted and continue local cleanup. 403 routes through
+// mapForbiddenError for friendly admin/membership messaging.
 func deleteWorker(ctx context.Context, baseURL, authToken, teamID, workerID string) (notFound bool, err error) {
-	url := baseURL + "/api/teams/" + teamID + "/workers/" + workerID
-	status, raw, err := httpDo(ctx, http.MethodDelete, url, authToken, nil)
+	requestURL := baseURL + "/api/teams/" + teamID + "/workers/" + workerID
+	status, raw, err := httpDo(ctx, http.MethodDelete, requestURL, authToken, nil)
 	if err != nil {
 		return false, err
 	}
 	if status == http.StatusNotFound {
 		return true, nil
+	}
+	if status == http.StatusForbidden {
+		return false, mapForbiddenError(raw)
 	}
 	if status < 200 || status >= 300 {
 		return false, fmt.Errorf("server returned %d: %s", status, extractServerError(raw))

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -202,9 +202,25 @@ func postWorker(ctx context.Context, baseURL, authToken, teamID, name string) (*
 	return &worker, nil
 }
 
-// fetchWorkers calls GET /api/teams/{teamID}/workers.
+// fetchWorkers calls GET /api/teams/{teamID}/workers. The default response
+// excludes workers in `retired_quarantined` (the 30-day soft-delete window
+// after `worker rm --delete-on-server`).
 func fetchWorkers(ctx context.Context, baseURL, authToken, teamID string) ([]workerAPI, error) {
+	return fetchWorkersWithOptions(ctx, baseURL, authToken, teamID, false)
+}
+
+// fetchWorkersWithOptions is fetchWorkers with an explicit
+// includeQuarantined flag. When true, the request adds
+// `?include=quarantined` so the server returns soft-deleted workers
+// alongside live ones — used by `worker list --all` (justtunnel-cli#50,
+// justtunnel-server F-20). The default path goes through fetchWorkers so
+// quota-counting consumers (status, install, uninstall, rm) keep matching
+// the dashboard view.
+func fetchWorkersWithOptions(ctx context.Context, baseURL, authToken, teamID string, includeQuarantined bool) ([]workerAPI, error) {
 	url := baseURL + "/api/teams/" + teamID + "/workers"
+	if includeQuarantined {
+		url += "?include=quarantined"
+	}
 	status, raw, err := httpDo(ctx, http.MethodGet, url, authToken, nil)
 	if err != nil {
 		return nil, err

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -108,6 +108,18 @@ func loadWorkerEnv() (cfg *config.Config, teamID, ctxName, baseURL string, err e
 	if err != nil {
 		return nil, "", "", "", fmt.Errorf("parse server URL: %w", err)
 	}
+	// F-21: refuse early when the active team context is a stale slug the
+	// user is no longer a member of. Without this check, every worker
+	// subcommand fails with an opaque 403/404 from the team-scoped REST
+	// route. stalenessAnnotation returns "" when verification is not
+	// possible (offline, older server, ULID-shaped identifier), so we
+	// preserve compatibility and offline workflows.
+	if stalenessAnnotation(cfg, ctxName) != "" {
+		return nil, "", "", "", display.InputError(fmt.Sprintf(
+			"active context %s is invalid — you are not a member of that team. Run `justtunnel context use personal` (or `context use team:<slug>` for a current team) and retry.",
+			ctxName,
+		))
+	}
 	return cfg, teamID, ctxName, baseURL, nil
 }
 

--- a/cmd/worker_install.go
+++ b/cmd/worker_install.go
@@ -223,7 +223,7 @@ func ensureWorkerRegistered(ctx context.Context, baseURL, authToken, teamID, ctx
 		return nil, fmt.Errorf("read local worker config: %w", localErr)
 	}
 
-	servers, fetchErr := fetchWorkers(ctx, baseURL, authToken, teamID)
+	servers, fetchErr := fetchWorkers(ctx, baseURL, authToken, teamID, FetchWorkersOptions{})
 	if fetchErr != nil {
 		return nil, fmt.Errorf("list workers: %w", fetchErr)
 	}

--- a/cmd/worker_list.go
+++ b/cmd/worker_list.go
@@ -50,7 +50,7 @@ func runWorkerList(cmd *cobra.Command, args []string) error {
 	// The default endpoint strips them entirely (justtunnel-server #170 /
 	// F-16) so the billing quota stays accurate; without the explicit
 	// query param the --all flag would be a dead toggle (F-20).
-	serverWorkers, err := fetchWorkersWithOptions(cmd.Context(), baseURL, cfg.AuthToken, teamID, workerListAll)
+	serverWorkers, err := fetchWorkers(cmd.Context(), baseURL, cfg.AuthToken, teamID, FetchWorkersOptions{IncludeQuarantined: workerListAll})
 	if err != nil {
 		return err
 	}
@@ -184,8 +184,14 @@ func mergeWorkers(server []workerAPI, local []worker.Config, ctxName string) []w
 // (status=retired_quarantined). The default `worker list` view hides
 // these so a freshly-deleted worker doesn't linger for 30 days; pass
 // --all to see them. See justtunnel-cli#50.
+//
+// We allocate a fresh output slice rather than aliasing rows[:0]: the
+// in-place pattern mutates the caller's backing array as a side effect,
+// which is a footgun if any future caller also retains the original
+// slice. Allocation cost is negligible against the user-bounded number
+// of workers.
 func filterQuarantined(rows []workerRow) []workerRow {
-	out := rows[:0]
+	out := make([]workerRow, 0, len(rows))
 	for _, row := range rows {
 		if row.Status == "retired_quarantined" {
 			continue

--- a/cmd/worker_list.go
+++ b/cmd/worker_list.go
@@ -46,7 +46,11 @@ func runWorkerList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	serverWorkers, err := fetchWorkers(cmd.Context(), baseURL, cfg.AuthToken, teamID)
+	// When --all is set, ask the server to include quarantined workers.
+	// The default endpoint strips them entirely (justtunnel-server #170 /
+	// F-16) so the billing quota stays accurate; without the explicit
+	// query param the --all flag would be a dead toggle (F-20).
+	serverWorkers, err := fetchWorkersWithOptions(cmd.Context(), baseURL, cfg.AuthToken, teamID, workerListAll)
 	if err != nil {
 		return err
 	}
@@ -58,6 +62,10 @@ func runWorkerList(cmd *cobra.Command, args []string) error {
 
 	rows := mergeWorkers(serverWorkers, localWorkers, ctxName)
 	if !workerListAll {
+		// Defense-in-depth: the server already strips quarantined rows for
+		// the default listing, but keep the client-side filter so a stale
+		// CLI talking to a future server that surfaces quarantined rows
+		// without an explicit opt-in still hides them by default.
 		rows = filterQuarantined(rows)
 	}
 

--- a/cmd/worker_rm.go
+++ b/cmd/worker_rm.go
@@ -84,7 +84,7 @@ func runWorkerRm(cmd *cobra.Command, args []string) error {
 	// limits the worst case to "404 instead of 200" for the deleted-then-
 	// recreated case rather than wrong-target deletion. Acceptable for
 	// v1; revisit if we expose multi-admin team workflows.
-	workers, err := fetchWorkers(cmd.Context(), baseURL, cfg.AuthToken, teamID)
+	workers, err := fetchWorkers(cmd.Context(), baseURL, cfg.AuthToken, teamID, FetchWorkersOptions{})
 	if err != nil {
 		return err
 	}

--- a/cmd/worker_status.go
+++ b/cmd/worker_status.go
@@ -60,7 +60,7 @@ func runWorkerStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	serverWorkers, err := fetchWorkers(cmd.Context(), baseURL, cfg.AuthToken, teamID)
+	serverWorkers, err := fetchWorkers(cmd.Context(), baseURL, cfg.AuthToken, teamID, FetchWorkersOptions{})
 	if err != nil {
 		return err
 	}

--- a/cmd/worker_test.go
+++ b/cmd/worker_test.go
@@ -43,6 +43,18 @@ func resetWorkerState(t *testing.T, cfg *config.Config) string {
 	workerUninstallDeleteOnServer = false
 	workerUninstallForce = false
 	workerListAll = false
+	// loadWorkerEnv now performs an F-21 staleness check by hitting
+	// /api/memberships. The single-handler stubs used by worker tests
+	// don't model that endpoint and would either decode garbage as an
+	// empty membership list (false-positive stale) or return arbitrary
+	// success bodies. Default to "endpoint unsupported" (supported=false)
+	// so the staleness check fails open in worker tests; tests that
+	// specifically want to exercise the stale path can override
+	// fetchMemberships themselves.
+	previousFetcher := fetchMemberships
+	fetchMemberships = func(client *http.Client, baseURL, authToken string) ([]membership, bool, error) {
+		return nil, false, nil
+	}
 	t.Cleanup(func() {
 		workerRmDeleteOnServer = false
 		workerInstallNoLinger = false
@@ -50,8 +62,45 @@ func resetWorkerState(t *testing.T, cfg *config.Config) string {
 		workerUninstallDeleteOnServer = false
 		workerUninstallForce = false
 		workerListAll = false
+		fetchMemberships = previousFetcher
 	})
 	return path
+}
+
+// TestWorkerCommandRejectsStaleContext verifies F-21 on the worker
+// command path: when the active context is a team the user is no longer a
+// member of, worker subcommands fail fast with an actionable message
+// referencing `context use personal`, instead of the opaque 403/404 from
+// the team-scoped REST route.
+func TestWorkerCommandRejectsStaleContext(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		// Worker REST calls should never run — loadWorkerEnv must abort
+		// before reaching them.
+		t.Errorf("unexpected request to %s; loadWorkerEnv should have aborted", request.URL.Path)
+		writer.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer stub.Close()
+
+	resetWorkerState(t, teamCfg(stub.URL))
+
+	// Override the fetcher installed by resetWorkerState so the membership
+	// check actually runs and reports the active team as missing.
+	previousFetcher := fetchMemberships
+	t.Cleanup(func() { fetchMemberships = previousFetcher })
+	fetchMemberships = func(client *http.Client, baseURL, authToken string) ([]membership, bool, error) {
+		return []membership{{TeamSlug: "some-other-team"}}, true, nil
+	}
+
+	_, err := runCmd(t, "worker", "list")
+	if err == nil {
+		t.Fatal("expected loadWorkerEnv to reject stale team context, got nil error")
+	}
+	if !strings.Contains(err.Error(), "context use personal") {
+		t.Errorf("error should reference recovery command; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "team-alpha") {
+		t.Errorf("error should mention the stale slug; got %v", err)
+	}
 }
 
 func teamCfg(serverURL string) *config.Config {

--- a/cmd/worker_test.go
+++ b/cmd/worker_test.go
@@ -52,9 +52,10 @@ func resetWorkerState(t *testing.T, cfg *config.Config) string {
 	// specifically want to exercise the stale path can override
 	// fetchMemberships themselves.
 	previousFetcher := fetchMemberships
-	fetchMemberships = func(client *http.Client, baseURL, authToken string) ([]membership, bool, error) {
-		return nil, false, nil
+	fetchMemberships = func(client *http.Client, baseURL, authToken string) ([]membership, bool, bool, error) {
+		return nil, false, false, nil
 	}
+	resetMembershipCache()
 	t.Cleanup(func() {
 		workerRmDeleteOnServer = false
 		workerInstallNoLinger = false
@@ -63,6 +64,7 @@ func resetWorkerState(t *testing.T, cfg *config.Config) string {
 		workerUninstallForce = false
 		workerListAll = false
 		fetchMemberships = previousFetcher
+		resetMembershipCache()
 	})
 	return path
 }
@@ -87,9 +89,10 @@ func TestWorkerCommandRejectsStaleContext(t *testing.T) {
 	// check actually runs and reports the active team as missing.
 	previousFetcher := fetchMemberships
 	t.Cleanup(func() { fetchMemberships = previousFetcher })
-	fetchMemberships = func(client *http.Client, baseURL, authToken string) ([]membership, bool, error) {
-		return []membership{{TeamSlug: "some-other-team"}}, true, nil
+	fetchMemberships = func(client *http.Client, baseURL, authToken string) ([]membership, bool, bool, error) {
+		return []membership{{TeamSlug: "some-other-team"}}, true, false, nil
 	}
+	resetMembershipCache()
 
 	_, err := runCmd(t, "worker", "list")
 	if err == nil {
@@ -824,5 +827,208 @@ func TestWorkerListSubdomainFallsBackToLocal(t *testing.T) {
 	}
 	if !strings.Contains(out, "alice--team-alpha") {
 		t.Errorf("subdomain should fall back to local value, got: %s", out)
+	}
+}
+
+// TestPostWorkerMapsForbiddenNotMember verifies C-2: a 403 with a "not a
+// member" body is converted into a friendly display.InputError suggesting
+// `context use personal` rather than the opaque "server returned 403"
+// previously surfaced.
+func TestPostWorkerMapsForbiddenNotMember(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusForbidden)
+		writer.Write([]byte(`{"error":"not a member of team-alpha"}`))
+	}))
+	defer stub.Close()
+
+	resetWorkerState(t, teamCfg(stub.URL))
+
+	_, err := runCmd(t, "worker", "create", "alice")
+	if err == nil {
+		t.Fatal("expected error for 403, got nil")
+	}
+	if !strings.Contains(err.Error(), "membership is no longer valid") {
+		t.Errorf("error should mention invalid membership; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "context use personal") {
+		t.Errorf("error should suggest recovery; got: %v", err)
+	}
+}
+
+// TestPostWorkerMapsForbiddenAdmin verifies C-2: a 403 with an "admin" hint
+// is converted into a "requires team admin role" message.
+func TestPostWorkerMapsForbiddenAdmin(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusForbidden)
+		writer.Write([]byte(`{"error":"only team admins can create workers"}`))
+	}))
+	defer stub.Close()
+
+	resetWorkerState(t, teamCfg(stub.URL))
+
+	_, err := runCmd(t, "worker", "create", "alice")
+	if err == nil {
+		t.Fatal("expected error for 403, got nil")
+	}
+	if !strings.Contains(err.Error(), "team admin role") {
+		t.Errorf("error should mention admin role; got: %v", err)
+	}
+}
+
+// TestFetchWorkersMapsForbiddenGeneric verifies C-2 fall-through: a 403
+// body that doesn't match the "not a member" or "admin" heuristics still
+// surfaces with the body content rather than as opaque "server returned
+// 403". This exercises the fetchWorkers path (used by `worker list`).
+func TestFetchWorkersMapsForbiddenGeneric(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusForbidden)
+		writer.Write([]byte(`{"error":"plan does not allow this action"}`))
+	}))
+	defer stub.Close()
+
+	resetWorkerState(t, teamCfg(stub.URL))
+
+	_, err := runCmd(t, "worker", "list")
+	if err == nil {
+		t.Fatal("expected error for 403, got nil")
+	}
+	if !strings.Contains(err.Error(), "forbidden") {
+		t.Errorf("generic 403 should surface as 'forbidden: ...'; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "plan does not allow") {
+		t.Errorf("error should include server's body; got: %v", err)
+	}
+}
+
+// TestDeleteWorkerMapsForbidden verifies C-2 on the DELETE path
+// (justtunnel-server admin-gates `worker rm --delete-on-server` for
+// non-admins).
+func TestDeleteWorkerMapsForbidden(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method == http.MethodGet {
+			writer.Header().Set("Content-Type", "application/json")
+			writer.Write([]byte(`{"workers":[{"id":"wkr_x","name":"alice","team_id":"team-alpha"}]}`))
+			return
+		}
+		writer.WriteHeader(http.StatusForbidden)
+		writer.Write([]byte(`{"error":"only team admins can delete workers"}`))
+	}))
+	defer stub.Close()
+
+	resetWorkerState(t, teamCfg(stub.URL))
+	if err := worker.Write(&worker.Config{WorkerID: "wkr_x", Name: "alice", Context: "team:team-alpha", ServiceBackend: "none"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	_, err := runCmd(t, "worker", "rm", "alice", "--delete-on-server")
+	if err == nil {
+		t.Fatal("expected error on 403, got nil")
+	}
+	if !strings.Contains(err.Error(), "team admin role") {
+		t.Errorf("error should mention admin role; got: %v", err)
+	}
+}
+
+// TestWorkerListFiltersQuarantinedOnDefaultEvenIfServerReturnsThem
+// verifies C-6: filterQuarantined strips quarantined rows even if the
+// server returns them on the default endpoint, and proves
+// filterQuarantined no longer aliases the input slice's backing array.
+func TestWorkerListFiltersQuarantinedOnDefaultEvenIfServerReturnsThem(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		// Server (broken or stale) returns a quarantined row even on the
+		// default endpoint. Defense-in-depth: client filter must strip it.
+		writer.Write([]byte(`{"workers":[
+			{"id":"wkr_a","name":"alice","team_id":"team-alpha","subdomain":"alice--team-alpha","status":"online"},
+			{"id":"wkr_q","name":"qrow","team_id":"team-alpha","subdomain":"qrow--team-alpha","status":"retired_quarantined"}
+		]}`))
+	}))
+	defer stub.Close()
+
+	resetWorkerState(t, teamCfg(stub.URL))
+
+	out, err := runCmd(t, "worker", "list")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(out, "alice") {
+		t.Errorf("expected alice in output: %s", out)
+	}
+	if strings.Contains(out, "qrow") {
+		t.Errorf("client must filter quarantined even when server returns them: %s", out)
+	}
+}
+
+// TestFilterQuarantinedDoesNotMutateInput is a unit-level guard against
+// the rows[:0] aliasing footgun: filterQuarantined must return a fresh
+// slice, leaving the caller's input untouched.
+func TestFilterQuarantinedDoesNotMutateInput(t *testing.T) {
+	input := []workerRow{
+		{Name: "alice", Status: "online"},
+		{Name: "ghost", Status: "retired_quarantined"},
+		{Name: "bob", Status: "online"},
+	}
+	originalLen := len(input)
+	originalNames := []string{input[0].Name, input[1].Name, input[2].Name}
+
+	out := filterQuarantined(input)
+
+	if len(out) != 2 {
+		t.Errorf("filtered output should have 2 rows, got %d", len(out))
+	}
+	// Input slice must be untouched — header AND backing array.
+	if len(input) != originalLen {
+		t.Errorf("input slice header was modified: len=%d, want %d", len(input), originalLen)
+	}
+	for index, want := range originalNames {
+		if input[index].Name != want {
+			t.Errorf("input[%d].Name was mutated: got %q, want %q", index, input[index].Name, want)
+		}
+	}
+}
+
+// TestWorkerCommandsHappyPathThroughStalenessCheck verifies C-7: when the
+// active team appears in the membership list, loadWorkerEnv proceeds
+// without error all the way through to the actual REST call. This
+// exercises the previously-untested staleness-check happy path.
+func TestWorkerCommandsHappyPathThroughStalenessCheck(t *testing.T) {
+	var membershipsHits, workersHits int32
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		// Assert auth header on every request.
+		if got := request.Header.Get("Authorization"); got != "Bearer justtunnel_test_token" {
+			t.Errorf("Authorization: got %q, want %q", got, "Bearer justtunnel_test_token")
+		}
+		switch request.URL.Path {
+		case "/api/memberships":
+			atomic.AddInt32(&membershipsHits, 1)
+			writer.Header().Set("Content-Type", "application/json")
+			writer.Write([]byte(`{"memberships":[{"team_slug":"team-alpha"}]}`))
+		case "/api/teams/team-alpha/workers":
+			atomic.AddInt32(&workersHits, 1)
+			writer.Header().Set("Content-Type", "application/json")
+			writer.Write([]byte(`{"workers":[]}`))
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer stub.Close()
+
+	resetWorkerState(t, teamCfg(stub.URL))
+
+	// Override the default-stub fetcher installed by resetWorkerState so the
+	// real fetchMembershipsHTTP runs against our stub server.
+	previousFetcher := fetchMemberships
+	t.Cleanup(func() { fetchMemberships = previousFetcher })
+	fetchMemberships = fetchMembershipsHTTP
+	resetMembershipCache()
+
+	if _, err := runCmd(t, "worker", "list"); err != nil {
+		t.Fatalf("list should succeed for current team: %v", err)
+	}
+	if atomic.LoadInt32(&membershipsHits) < 1 {
+		t.Errorf("memberships endpoint should have been called at least once")
+	}
+	if atomic.LoadInt32(&workersHits) != 1 {
+		t.Errorf("workers endpoint should have been called exactly once, got %d", workersHits)
 	}
 }

--- a/cmd/worker_test.go
+++ b/cmd/worker_test.go
@@ -734,7 +734,9 @@ func TestWorkerRmDeleteOnServerMessageReflectsQuarantine(t *testing.T) {
 // soft-deleted, otherwise a user who just ran `rm --delete-on-server`
 // sees their "deleted" worker still listed.
 func TestWorkerListHidesQuarantinedByDefault(t *testing.T) {
+	var observedInclude string
 	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		observedInclude = request.URL.Query().Get("include")
 		writer.Header().Set("Content-Type", "application/json")
 		writer.Write([]byte(`{"workers":[
 		    {"id":"wkr_a","name":"alice","team_id":"team-alpha","subdomain":"alice--team-alpha","status":"online"},
@@ -755,13 +757,28 @@ func TestWorkerListHidesQuarantinedByDefault(t *testing.T) {
 	if strings.Contains(out, "zombie") {
 		t.Errorf("quarantined worker should be hidden by default: %s", out)
 	}
+	// Default mode must NOT pass `?include=quarantined` so the server keeps
+	// the billing-quota-accurate filtered view (justtunnel-server #170).
+	if observedInclude != "" {
+		t.Errorf("default list must not request quarantined; got include=%q", observedInclude)
+	}
 }
 
 // TestWorkerListAllShowsQuarantined verifies the --all flag opts the
 // quarantined rows back in.
 func TestWorkerListAllShowsQuarantined(t *testing.T) {
+	var observedInclude string
 	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		observedInclude = request.URL.Query().Get("include")
 		writer.Header().Set("Content-Type", "application/json")
+		// Server only echoes back quarantined rows when explicitly asked
+		// (justtunnel-server F-20). If the CLI omits the query param the
+		// stub returns nothing, so the assertions below also catch a
+		// regression where --all silently drops the include flag.
+		if observedInclude != "quarantined" {
+			writer.Write([]byte(`{"workers":[]}`))
+			return
+		}
 		writer.Write([]byte(`{"workers":[
 		    {"id":"wkr_z","name":"zombie","team_id":"team-alpha","subdomain":"zombie--team-alpha","status":"retired_quarantined"}
 		]}`))
@@ -773,6 +790,9 @@ func TestWorkerListAllShowsQuarantined(t *testing.T) {
 	out, err := runCmd(t, "worker", "list", "--all")
 	if err != nil {
 		t.Fatalf("list --all: %v", err)
+	}
+	if observedInclude != "quarantined" {
+		t.Fatalf("--all must send ?include=quarantined; got include=%q", observedInclude)
 	}
 	if !strings.Contains(out, "zombie") {
 		t.Errorf("--all should reveal quarantined rows: %s", out)

--- a/cmd/worker_uninstall.go
+++ b/cmd/worker_uninstall.go
@@ -258,7 +258,7 @@ func removeLocalConfig(name string) (bool, error) {
 // already absent from the list — is treated as already-deleted; in the
 // 404 case we log to stderr so the operator knows what happened.
 func uninstallServerSide(ctx context.Context, baseURL, authToken, teamID, name string, warnOut io.Writer) error {
-	workers, err := fetchWorkers(ctx, baseURL, authToken, teamID)
+	workers, err := fetchWorkers(ctx, baseURL, authToken, teamID, FetchWorkersOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Two bug fixes from the 2026-05-07 QA pass.

- **F-21**: `context show` now annotates a stale active-context slug as `(invalid — not a member; run \`justtunnel context use personal\` to clear)` when the slug isn't in the user's membership list. Read-only — no config mutation. Worker subcommands hard-error with the same actionable hint instead of failing opaquely at request time. Both paths fail open on offline / older-server / ULID-shaped identifiers to preserve compatibility.
- **F-20 (CLI half)**: `worker list --all` now sends `?include=quarantined` to the server. Other consumers (default `worker list`, quota-related calls) stay quota-accurate. Existing client-side `filterQuarantined` kept as a defense-in-depth no-op.

## Verification

- `go vet ./...` — clean
- `go test -race ./...` — all packages pass
- Live re-verify in QA pass 2 (`.planning/qa-2026-05-07/pass2-findings.md`):
  - F-21: planted `current_context: team:does-not-exist-xyz` in `~/.config/justtunnel/config.yaml`. `context show` printed the annotation (exit 0). `worker list` hard-errored with the actionable hint (exit 1). Config restored after.
  - F-20: throwaway worker quarantined via `worker rm --delete-on-server`. Default `worker list` empty. `worker list --all` showed 5 quarantined workers including the new one with status `retired_quarantined`.

## Test plan

- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] Live stale-context repro
- [x] Live `--all` flag against quarantined data
