### PR TITLE
ci: merge-preflight job (catches concurrent-PR semantic conflicts)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,39 @@ jobs:
 
       - name: Test
         run: go test -race ./...
+
+  # merge-preflight catches semantic conflicts between concurrent PRs that
+  # individually pass CI but break main once merged together (e.g. two
+  # PRs adding a same-named symbol, or one renaming a function the other
+  # depends on). Runs go vet + tests against the PR branch merged with the
+  # *current* origin/main. PR-only — push-to-main is already a real merged
+  # state covered by `build` above.
+  merge-preflight:
+    name: Merge preflight (vs latest main)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Merge latest main into PR head
+        run: |
+          git config user.email "ci@justtunnel.dev"
+          git config user.name "ci"
+          git fetch origin main
+          git merge --no-edit origin/main
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -race ./...


### PR DESCRIPTION
## Summary

Adds a `merge-preflight` job to CLI CI that mirrors the same defense added to `justtunnel-server` in [justtunnel-server#228](https://github.com/justtunnel/justtunnel-server/pull/228).

**Why:** Two concurrent PRs branched from the same base can each pass per-PR CI in isolation but break main when both merge — e.g. both declare `type Foo struct` in the same package, or one renames a function the other depends on. The server hit exactly this on 2026-05-08 (`recordingEmailer redeclared in this block`), which gated and skipped the Fly deploy. The CLI doesn't currently have parallel-PR pressure but the cost of adding the job is ~30s and the protection is identical.

**How:** On PR events, check out the PR head, merge `origin/main` into it, then run `go build`, `go vet`, and `go test -race` against the merged state — exactly what will land on main after merge.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses
- [ ] `merge-preflight` runs green on this PR (no skew possible — branch is identical to main)
- [ ] Future merge-skew breakage fails the offending PR's `merge-preflight` instead of main's post-push CI
