### PR TITLE
HTTP calls use http.DefaultClient (no timeout) — server stall hangs the CLI

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -73,7 +73,7 @@ func runKeyAuth(_ *cobra.Command, key string) error {
 		return fmt.Errorf("parse server URL: %w", err)
 	}
 
-	result, err := verifyKey(http.DefaultClient, baseURL, key)
+	result, err := verifyKey(&http.Client{Timeout: httpTimeout}, baseURL, key)
 	if err != nil {
 		return categorizeAuthError(err)
 	}
@@ -104,7 +104,7 @@ func runDeviceAuth(cmd *cobra.Command) error {
 
 	// Check if already authenticated
 	if cfg.AuthToken != "" {
-		result, verifyErr := verifyKey(http.DefaultClient, baseURL, cfg.AuthToken)
+		result, verifyErr := verifyKey(&http.Client{Timeout: httpTimeout}, baseURL, cfg.AuthToken)
 		if verifyErr == nil {
 			displayName := result.GitHubUsername
 			if displayName == "" {
@@ -121,7 +121,7 @@ func runDeviceAuth(cmd *cobra.Command) error {
 	}
 
 	// Create device session
-	deviceResp, err := createDeviceSession(http.DefaultClient, baseURL)
+	deviceResp, err := createDeviceSession(&http.Client{Timeout: httpTimeout}, baseURL)
 	if err != nil {
 		return categorizeAuthError(err)
 	}
@@ -154,6 +154,8 @@ func runDeviceAuth(cmd *cobra.Command) error {
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
+	httpClient := &http.Client{Timeout: httpTimeout}
+
 	for {
 		select {
 		case <-sigCtx.Done():
@@ -163,7 +165,7 @@ func runDeviceAuth(cmd *cobra.Command) error {
 			}
 			return display.InputError("authentication cancelled")
 		case <-ticker.C:
-			status, pollErr := pollDeviceStatus(http.DefaultClient, baseURL, deviceResp.DeviceCode)
+			status, pollErr := pollDeviceStatus(httpClient, baseURL, deviceResp.DeviceCode)
 			if pollErr != nil {
 				continue // retry on network errors
 			}
@@ -184,7 +186,7 @@ func runDeviceAuth(cmd *cobra.Command) error {
 				}
 
 				// Verify and display user info
-				result, verifyErr := verifyKey(http.DefaultClient, baseURL, status.APIKey)
+				result, verifyErr := verifyKey(httpClient, baseURL, status.APIKey)
 				if verifyErr != nil {
 					// Key saved but verify failed — still OK
 					fmt.Println("Authenticated successfully.")

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -17,6 +17,7 @@ import (
 	"github.com/justtunnel/justtunnel-cli/internal/browser"
 	"github.com/justtunnel/justtunnel-cli/internal/config"
 	"github.com/justtunnel/justtunnel-cli/internal/display"
+	"github.com/justtunnel/justtunnel-cli/internal/httpclient"
 )
 
 type authVerifyResponse struct {
@@ -73,7 +74,7 @@ func runKeyAuth(_ *cobra.Command, key string) error {
 		return fmt.Errorf("parse server URL: %w", err)
 	}
 
-	result, err := verifyKey(&http.Client{Timeout: httpTimeout}, baseURL, key)
+	result, err := verifyKey(&http.Client{Timeout: httpclient.Timeout}, baseURL, key)
 	if err != nil {
 		return categorizeAuthError(err)
 	}
@@ -104,7 +105,7 @@ func runDeviceAuth(cmd *cobra.Command) error {
 
 	// Check if already authenticated
 	if cfg.AuthToken != "" {
-		result, verifyErr := verifyKey(&http.Client{Timeout: httpTimeout}, baseURL, cfg.AuthToken)
+		result, verifyErr := verifyKey(&http.Client{Timeout: httpclient.Timeout}, baseURL, cfg.AuthToken)
 		if verifyErr == nil {
 			displayName := result.GitHubUsername
 			if displayName == "" {
@@ -121,7 +122,7 @@ func runDeviceAuth(cmd *cobra.Command) error {
 	}
 
 	// Create device session
-	deviceResp, err := createDeviceSession(&http.Client{Timeout: httpTimeout}, baseURL)
+	deviceResp, err := createDeviceSession(&http.Client{Timeout: httpclient.Timeout}, baseURL)
 	if err != nil {
 		return categorizeAuthError(err)
 	}
@@ -154,7 +155,7 @@ func runDeviceAuth(cmd *cobra.Command) error {
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
-	httpClient := &http.Client{Timeout: httpTimeout}
+	httpClient := &http.Client{Timeout: httpclient.Timeout}
 
 	for {
 		select {

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestVerifyKeyValid(t *testing.T) {
@@ -68,12 +69,41 @@ func TestVerifyKeyForbidden(t *testing.T) {
 }
 
 func TestVerifyKeyNetworkError(t *testing.T) {
-	_, err := verifyKey(http.DefaultClient, "http://127.0.0.1:1", "justtunnel_key")
+	// Bound the client so a (very unlikely) reachable 127.0.0.1:1 can't hang
+	// the test, matching the timeout-bearing clients production code now uses.
+	_, err := verifyKey(&http.Client{Timeout: 2 * time.Second}, "http://127.0.0.1:1", "justtunnel_key")
 	if err == nil {
 		t.Fatal("expected error for network failure")
 	}
 	if err.Error() != "could not reach justtunnel server" {
 		t.Errorf("error message: got %q, want %q", err.Error(), "could not reach justtunnel server")
+	}
+}
+
+// TestVerifyKeyServerStall is the core CLI-2 regression: a server that
+// accepts the connection then never responds must not hang the CLI. The
+// client's Timeout has to bound the call. The handler blocks on the request
+// context so it unblocks cleanly when the client cancels.
+func TestVerifyKeyServerStall(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		<-request.Context().Done()
+	}))
+	defer server.Close()
+
+	client := &http.Client{Timeout: 100 * time.Millisecond}
+	done := make(chan error, 1)
+	go func() {
+		_, err := verifyKey(client, server.URL, "justtunnel_key")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected timeout error from stalling server, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("verifyKey did not return within 5s — timeout did not bound the stalling server")
 	}
 }
 

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/justtunnel/justtunnel-cli/internal/config"
 	"github.com/justtunnel/justtunnel-cli/internal/display"
+	"github.com/justtunnel/justtunnel-cli/internal/httpclient"
 )
 
 // membership represents a single team membership returned by the server.
@@ -440,7 +441,7 @@ func looksLikeULID(identifier string) bool {
 // can treat that as a definitive "not a member" signal (vs a transient 5xx).
 func fetchMembershipsHTTP(client *http.Client, baseURL, authToken string) ([]membership, bool, bool, error) {
 	if client == nil {
-		client = &http.Client{Timeout: 10 * time.Second}
+		client = &http.Client{Timeout: httpclient.Timeout}
 	}
 	req, err := http.NewRequest(http.MethodGet, baseURL+"/api/memberships", nil)
 	if err != nil {
@@ -487,7 +488,7 @@ func fetchMembershipsHTTP(client *http.Client, baseURL, authToken string) ([]mem
 // (caller validates first via config.ValidateContext).
 func pushActiveContextHTTP(client *http.Client, baseURL, authToken, contextName string) error {
 	if client == nil {
-		client = &http.Client{Timeout: 10 * time.Second}
+		client = &http.Client{Timeout: httpclient.Timeout}
 	}
 
 	var body struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -500,7 +500,9 @@ func ensureAuthenticated(cfg *config.Config, cmd *cobra.Command) error {
 
 	fmt.Fprintf(os.Stderr, "\n  Welcome to justtunnel! Sign in with GitHub to get started.\n\n")
 
-	deviceResp, err := createDeviceSession(http.DefaultClient, baseURL)
+	httpClient := &http.Client{Timeout: httpTimeout}
+
+	deviceResp, err := createDeviceSession(httpClient, baseURL)
 	if err != nil {
 		return categorizeAuthError(err)
 	}
@@ -538,7 +540,7 @@ func ensureAuthenticated(cfg *config.Config, cmd *cobra.Command) error {
 			}
 			return display.InputError("authentication cancelled")
 		case <-ticker.C:
-			status, pollErr := pollDeviceStatus(http.DefaultClient, baseURL, deviceResp.DeviceCode)
+			status, pollErr := pollDeviceStatus(httpClient, baseURL, deviceResp.DeviceCode)
 			if pollErr != nil {
 				continue
 			}
@@ -557,7 +559,7 @@ func ensureAuthenticated(cfg *config.Config, cmd *cobra.Command) error {
 					return fmt.Errorf("save config: %w", saveErr)
 				}
 
-				result, verifyErr := verifyKey(http.DefaultClient, baseURL, status.APIKey)
+				result, verifyErr := verifyKey(httpClient, baseURL, status.APIKey)
 				if verifyErr != nil {
 					fmt.Fprintf(os.Stderr, "\n  Authenticated successfully. Starting tunnel...\n\n")
 					return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/justtunnel/justtunnel-cli/internal/browser"
 	"github.com/justtunnel/justtunnel-cli/internal/config"
 	"github.com/justtunnel/justtunnel-cli/internal/display"
+	"github.com/justtunnel/justtunnel-cli/internal/httpclient"
 	"github.com/justtunnel/justtunnel-cli/internal/tui"
 	"github.com/justtunnel/justtunnel-cli/internal/tunnel"
 	"github.com/justtunnel/justtunnel-cli/internal/version"
@@ -500,7 +501,7 @@ func ensureAuthenticated(cfg *config.Config, cmd *cobra.Command) error {
 
 	fmt.Fprintf(os.Stderr, "\n  Welcome to justtunnel! Sign in with GitHub to get started.\n\n")
 
-	httpClient := &http.Client{Timeout: httpTimeout}
+	httpClient := &http.Client{Timeout: httpclient.Timeout}
 
 	deviceResp, err := createDeviceSession(httpClient, baseURL)
 	if err != nil {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -58,7 +58,8 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.AuthToken)
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{Timeout: httpTimeout}
+	resp, err := client.Do(req)
 	if err != nil {
 		return display.NetworkError("could not reach justtunnel server")
 	}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/justtunnel/justtunnel-cli/internal/config"
 	"github.com/justtunnel/justtunnel-cli/internal/display"
+	"github.com/justtunnel/justtunnel-cli/internal/httpclient"
 )
 
 type tunnelInfo struct {
@@ -58,7 +59,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.AuthToken)
 
-	client := &http.Client{Timeout: httpTimeout}
+	client := &http.Client{Timeout: httpclient.Timeout}
 	resp, err := client.Do(req)
 	if err != nil {
 		return display.NetworkError("could not reach justtunnel server")

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -9,12 +9,12 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/justtunnel/justtunnel-cli/internal/config"
 	"github.com/justtunnel/justtunnel-cli/internal/display"
+	"github.com/justtunnel/justtunnel-cli/internal/httpclient"
 )
 
 // workerAPI mirrors the JSON shape returned by the server for a single
@@ -37,11 +37,6 @@ type workerAPI struct {
 type workerListResponse struct {
 	Workers []workerAPI `json:"workers"`
 }
-
-// httpTimeout matches the 10s timeout used by other subcommands so behavior
-// is consistent against an unresponsive server. Declared as a var (not const)
-// so tests can shrink it to keep timeout cases fast.
-var httpTimeout = 10 * time.Second
 
 var workerCmd = &cobra.Command{
 	Use:   "worker",
@@ -155,7 +150,7 @@ func mapForbiddenError(body []byte) error {
 //
 // D1: ctx threads through to client.Do via req.WithContext so a SIGINT
 // during a long-running HTTP call (slow server, hung TLS handshake)
-// cancels the in-flight request rather than blocking until httpTimeout.
+// cancels the in-flight request rather than blocking until httpclient.Timeout.
 // Pass cmd.Context() from cobra handlers; pass context.Background() from
 // non-cobra callers (rare).
 func httpDo(ctx context.Context, method, url, authToken string, body io.Reader) (int, []byte, error) {
@@ -172,7 +167,7 @@ func httpDo(ctx context.Context, method, url, authToken string, body io.Reader) 
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	client := &http.Client{Timeout: httpTimeout}
+	client := &http.Client{Timeout: httpclient.Timeout}
 	resp, err := client.Do(req)
 	if err != nil {
 		return 0, nil, fmt.Errorf("request: %w", err)

--- a/cmd/worker_status_test.go
+++ b/cmd/worker_status_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/justtunnel/justtunnel-cli/internal/config"
+	"github.com/justtunnel/justtunnel-cli/internal/httpclient"
 	"github.com/justtunnel/justtunnel-cli/internal/worker"
 )
 
@@ -354,9 +355,9 @@ func TestWorkerStatusServerTimeout(t *testing.T) {
 	}))
 	defer stub.Close()
 
-	prev := httpTimeout
-	httpTimeout = 100 * time.Millisecond
-	t.Cleanup(func() { httpTimeout = prev })
+	prev := httpclient.Timeout
+	httpclient.Timeout = 100 * time.Millisecond
+	t.Cleanup(func() { httpclient.Timeout = prev })
 
 	resetWorkerState(t, teamCfg(stub.URL))
 	useFakeSupervisor(t, newFakeSupervisor())

--- a/internal/httpclient/httpclient.go
+++ b/internal/httpclient/httpclient.go
@@ -1,0 +1,14 @@
+// Package httpclient holds shared HTTP client configuration for the CLI.
+//
+// It exists so the request timeout has a single source of truth across the
+// cmd and tui packages. Before this, the 10s value was duplicated in
+// cmd/worker.go, cmd/context.go, and internal/tui/plan.go, which could
+// silently diverge.
+package httpclient
+
+import "time"
+
+// Timeout bounds every CLI HTTP call so a server that accepts the connection
+// then stalls cannot hang the CLI indefinitely. It is a var (not const) so
+// tests can shrink it to keep timeout cases fast.
+var Timeout = 10 * time.Second

--- a/internal/tui/plan.go
+++ b/internal/tui/plan.go
@@ -5,9 +5,15 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 // PlanInfo is defined in model.go — reused here for FetchPlanInfo.
+
+// httpTimeout bounds the /api/me plan-info request so an unresponsive server
+// cannot block TUI startup indefinitely. Matches the 10s timeout used by the
+// CLI subcommands.
+const httpTimeout = 10 * time.Second
 
 // planLimits maps plan names to their maximum number of concurrent tunnels.
 // This mirrors the server-side plan/limits.go configuration.
@@ -40,7 +46,8 @@ func FetchPlanInfo(serverURL string, token string) (PlanInfo, error) {
 	}
 	request.Header.Set("Authorization", "Bearer "+token)
 
-	response, err := http.DefaultClient.Do(request)
+	client := &http.Client{Timeout: httpTimeout}
+	response, err := client.Do(request)
 	if err != nil {
 		return PlanInfo{}, fmt.Errorf("fetch plan info: %w", err)
 	}

--- a/internal/tui/plan.go
+++ b/internal/tui/plan.go
@@ -5,15 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"time"
+
+	"github.com/justtunnel/justtunnel-cli/internal/httpclient"
 )
 
 // PlanInfo is defined in model.go — reused here for FetchPlanInfo.
-
-// httpTimeout bounds the /api/me plan-info request so an unresponsive server
-// cannot block TUI startup indefinitely. Matches the 10s timeout used by the
-// CLI subcommands.
-const httpTimeout = 10 * time.Second
 
 // planLimits maps plan names to their maximum number of concurrent tunnels.
 // This mirrors the server-side plan/limits.go configuration.
@@ -40,13 +36,13 @@ func FetchPlanInfo(serverURL string, token string) (PlanInfo, error) {
 		return PlanInfo{}, fmt.Errorf("parse server URL: %w", err)
 	}
 
-	request, err := http.NewRequest("GET", baseURL+"/api/me", nil)
+	request, err := http.NewRequest(http.MethodGet, baseURL+"/api/me", nil)
 	if err != nil {
 		return PlanInfo{}, fmt.Errorf("create request: %w", err)
 	}
 	request.Header.Set("Authorization", "Bearer "+token)
 
-	client := &http.Client{Timeout: httpTimeout}
+	client := &http.Client{Timeout: httpclient.Timeout}
 	response, err := client.Do(request)
 	if err != nil {
 		return PlanInfo{}, fmt.Errorf("fetch plan info: %w", err)

--- a/internal/tui/plan_test.go
+++ b/internal/tui/plan_test.go
@@ -5,6 +5,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/justtunnel/justtunnel-cli/internal/httpclient"
 )
 
 func TestFetchPlanInfo(t *testing.T) {
@@ -119,6 +122,37 @@ func TestFetchPlanInfo_NetworkError(t *testing.T) {
 	_, err := FetchPlanInfo("http://127.0.0.1:1", "test-token")
 	if err == nil {
 		t.Fatal("expected error for network failure, got nil")
+	}
+}
+
+// TestFetchPlanInfo_ServerStall is the CLI-2 regression for TUI startup: a
+// server that accepts the connection then never responds must not block the
+// TUI indefinitely. httpclient.Timeout bounds the call; we shrink it so the
+// test is fast. The handler blocks on the request context so it unblocks
+// cleanly when the client cancels.
+func TestFetchPlanInfo_ServerStall(t *testing.T) {
+	prev := httpclient.Timeout
+	httpclient.Timeout = 100 * time.Millisecond
+	t.Cleanup(func() { httpclient.Timeout = prev })
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		<-req.Context().Done()
+	}))
+	defer server.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := FetchPlanInfo(server.URL, "test-token")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected timeout error from stalling server, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("FetchPlanInfo did not return within 5s — timeout did not bound the stalling server")
 	}
 }
 


### PR DESCRIPTION
**Problem.** Device-auth (createDeviceSession/pollDeviceStatus/verifyKey), status, and TUI plan-fetch all use http.DefaultClient (Timeout: 0) with context-free requests. A server that accepts the connection then stalls hangs the CLI indefinitely with no Ctrl-C escape; plan.go blocks TUI startup entirely. The 10s-timeout pattern exists elsewhere precisely for this.

**Fix.** Replace http.DefaultClient with &http.Client{Timeout: httpTimeout} (or attach sigCtx via req.WithContext) at all these call sites, promoting httpTimeout to a shared location.

**Where.** justtunnel-cli/cmd/auth.go:204; justtunnel-cli/cmd/status.go:61; justtunnel-cli/internal/tui/plan.go:43; justtunnel-cli/cmd/root.go:503

Closes #62
