### PR TITLE
CLI reconnect/backoff state machine is untested

### DIFF
--- a/internal/tunnel/reconnect_test.go
+++ b/internal/tunnel/reconnect_test.go
@@ -23,13 +23,12 @@ import (
 // to handleConn, which the test supplies to decide what the server does for
 // that particular connection (e.g. accept then drop, or reject with 401).
 type fakeRelay struct {
-	server *httptest.Server
-
 	mu              sync.Mutex
 	dialCount       int
 	rejectFrom      int  // dials at or after this index get rejectStatus (0 = never)
 	rejectCode      int  // HTTP status used when rejecting before the WS upgrade
-	dropAfterAssign bool // when accepting, drop the connection right after tunnel_assigned
+	dropAfterAssign bool // when accepting, drop every connection right after tunnel_assigned
+	dropUntil       int  // accepted dials at or before this index are dropped after assign; later dials are held open (0 = never)
 }
 
 func newFakeRelay(t *testing.T, relay *fakeRelay) string {
@@ -41,6 +40,7 @@ func newFakeRelay(t *testing.T, relay *fakeRelay) string {
 		rejectFrom := relay.rejectFrom
 		rejectCode := relay.rejectCode
 		dropAfterAssign := relay.dropAfterAssign
+		dropUntil := relay.dropUntil
 		relay.mu.Unlock()
 
 		if rejectFrom > 0 && current >= rejectFrom {
@@ -66,7 +66,7 @@ func newFakeRelay(t *testing.T, relay *fakeRelay) string {
 			return
 		}
 
-		if dropAfterAssign {
+		if dropAfterAssign || (dropUntil > 0 && current <= dropUntil) {
 			// Simulate the relay dropping the connection. The CLI's read
 			// loop will see an abnormal closure and enter reconnect.
 			conn.Close(websocket.StatusAbnormalClosure, "server dropping")
@@ -78,7 +78,6 @@ func newFakeRelay(t *testing.T, relay *fakeRelay) string {
 		conn.Close(websocket.StatusNormalClosure, "")
 	}))
 	t.Cleanup(httpServer.Close)
-	relay.server = httpServer
 	return "ws" + strings.TrimPrefix(httpServer.URL, "http")
 }
 
@@ -149,6 +148,15 @@ func TestReconnectGivesUpAfterMaxAttempts(t *testing.T) {
 	}
 	if !strings.Contains(cliErr.Error(), "gave up reconnecting") {
 		t.Errorf("message: got %q, want it to mention giving up", cliErr.Error())
+	}
+	// The give-up message embeds attempt-1; with max=3 it must report 3 attempts.
+	if !strings.Contains(cliErr.Error(), "after 3 attempts") {
+		t.Errorf("message: got %q, want it to report 3 attempts", cliErr.Error())
+	}
+	// 1 initial dial + exactly 3 reconnect dials, then it gives up. Locks the
+	// off-by-one boundary at the attempt > maxReconnectAttempts check.
+	if dials := relay.dials(); dials != 4 {
+		t.Errorf("dial count: got %d, want 4 (initial + 3 reconnect attempts)", dials)
 	}
 }
 
@@ -268,41 +276,12 @@ func TestReconnectStopsOnForbiddenMidReconnect(t *testing.T) {
 // where the relay accepts the reconnect, and asserts OnReconnected fires and
 // the loop resumes without surfacing an error (until ctx is cancelled).
 func TestReconnectSucceedsAfterDrop(t *testing.T) {
-	var dialCount int
-	var mu sync.Mutex
 	reconnected := make(chan ReconnectInfo, 1)
 
-	httpServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		mu.Lock()
-		dialCount++
-		current := dialCount
-		mu.Unlock()
-
-		conn, err := websocket.Accept(writer, request, nil)
-		if err != nil {
-			return
-		}
-		assigned := TunnelAssigned{
-			Type:           "tunnel_assigned",
-			TunnelID:       "test-tunnel-id",
-			Subdomain:      "test-sub",
-			URL:            "https://test-sub.justtunnel.dev",
-			ReconnectToken: "reconnect-token",
-		}
-		data, _ := json.Marshal(assigned)
-		conn.Write(request.Context(), websocket.MessageText, data)
-
-		if current == 1 {
-			// Drop the first connection to trigger a reconnect.
-			conn.Close(websocket.StatusAbnormalClosure, "drop")
-			return
-		}
-		// Second (reconnect) connection: hold it open.
-		<-request.Context().Done()
-		conn.Close(websocket.StatusNormalClosure, "")
-	}))
-	t.Cleanup(httpServer.Close)
-	wsURL := "ws" + strings.TrimPrefix(httpServer.URL, "http")
+	// First dial is accepted then dropped to trigger a reconnect; the second
+	// (reconnect) dial is held open so the reconnect succeeds.
+	relay := &fakeRelay{dropUntil: 1}
+	wsURL := newFakeRelay(t, relay)
 
 	sleep, schedule := recordingSleep()
 	tun := New(wsURL, "http://localhost:0", "", discardLogger(), Callbacks{
@@ -338,6 +317,13 @@ func TestReconnectSucceedsAfterDrop(t *testing.T) {
 		t.Errorf("backoff before successful reconnect: got %v, want [1s]", got)
 	}
 
+	// Exactly 2 dials: the initial (dropped) connection plus one reconnect.
+	// Guards against an implementation that retries more than once before
+	// succeeding (e.g. an attempt-counter reset bug).
+	if dials := relay.dials(); dials != 2 {
+		t.Errorf("dial count: got %d, want 2 (initial drop + one successful reconnect)", dials)
+	}
+
 	cancel()
 	select {
 	case err := <-errCh:
@@ -346,5 +332,62 @@ func TestReconnectSucceedsAfterDrop(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Run did not return after context cancel")
+	}
+}
+
+// TestReconnectStopsOnContextCancelDuringBackoff covers graceful shutdown while
+// a reconnect is mid-backoff: when ctx is cancelled during the wait, Run returns
+// context.Canceled and no further reconnect dial is attempted. This exercises the
+// ctx.Err() propagation path out of waitWithCountdown/sleep that the other tests
+// (give-up, terminal 401/403, success) never reach.
+func TestReconnectStopsOnContextCancelDuringBackoff(t *testing.T) {
+	// Accept the first dial, drop it to trigger reconnect, then drop every
+	// subsequent dial so the loop would keep retrying if not cancelled.
+	relay := &fakeRelay{dropAfterAssign: true}
+	wsURL := newFakeRelay(t, relay)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Block the first backoff wait until ctx is cancelled, then surface
+	// ctx.Err() like realSleep would. Cancelling unblocks the wait.
+	waiting := make(chan struct{})
+	var once sync.Once
+	blockingSleep := func(sleepCtx context.Context, _ time.Duration) error {
+		once.Do(func() { close(waiting) })
+		<-sleepCtx.Done()
+		return sleepCtx.Err()
+	}
+
+	tun := New(wsURL, "http://localhost:0", "", discardLogger(), Callbacks{})
+	tun.sleep = blockingSleep
+	tun.SetMaxReconnectAttempts(10)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- tun.Run(ctx)
+	}()
+
+	select {
+	case <-waiting:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reconnect to enter backoff")
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("Run error after cancel during backoff: got %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after context cancel during backoff")
+	}
+
+	// 1 initial dial only. The reconnect never re-dialed because cancellation
+	// landed during the backoff wait, before the dial.
+	if dials := relay.dials(); dials != 1 {
+		t.Errorf("dial count: got %d, want 1 (initial only; no reconnect dial after cancel)", dials)
 	}
 }

--- a/internal/tunnel/reconnect_test.go
+++ b/internal/tunnel/reconnect_test.go
@@ -1,0 +1,350 @@
+package tunnel
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+
+	"github.com/justtunnel/justtunnel-cli/internal/display"
+)
+
+// fakeRelay is a controllable WebSocket relay used to drive the CLI through
+// disconnect -> reconnect cycles. Each incoming dial is recorded and dispatched
+// to handleConn, which the test supplies to decide what the server does for
+// that particular connection (e.g. accept then drop, or reject with 401).
+type fakeRelay struct {
+	server *httptest.Server
+
+	mu              sync.Mutex
+	dialCount       int
+	rejectFrom      int  // dials at or after this index get rejectStatus (0 = never)
+	rejectCode      int  // HTTP status used when rejecting before the WS upgrade
+	dropAfterAssign bool // when accepting, drop the connection right after tunnel_assigned
+}
+
+func newFakeRelay(t *testing.T, relay *fakeRelay) string {
+	t.Helper()
+	httpServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		relay.mu.Lock()
+		relay.dialCount++
+		current := relay.dialCount
+		rejectFrom := relay.rejectFrom
+		rejectCode := relay.rejectCode
+		dropAfterAssign := relay.dropAfterAssign
+		relay.mu.Unlock()
+
+		if rejectFrom > 0 && current >= rejectFrom {
+			http.Error(writer, "rejected", rejectCode)
+			return
+		}
+
+		conn, err := websocket.Accept(writer, request, nil)
+		if err != nil {
+			return
+		}
+
+		assigned := TunnelAssigned{
+			Type:           "tunnel_assigned",
+			TunnelID:       "test-tunnel-id",
+			Subdomain:      "test-sub",
+			URL:            "https://test-sub.justtunnel.dev",
+			ReconnectToken: "reconnect-token",
+		}
+		data, _ := json.Marshal(assigned)
+		if writeErr := conn.Write(request.Context(), websocket.MessageText, data); writeErr != nil {
+			conn.Close(websocket.StatusAbnormalClosure, "")
+			return
+		}
+
+		if dropAfterAssign {
+			// Simulate the relay dropping the connection. The CLI's read
+			// loop will see an abnormal closure and enter reconnect.
+			conn.Close(websocket.StatusAbnormalClosure, "server dropping")
+			return
+		}
+
+		// Hold the connection open until the client goes away.
+		<-request.Context().Done()
+		conn.Close(websocket.StatusNormalClosure, "")
+	}))
+	t.Cleanup(httpServer.Close)
+	relay.server = httpServer
+	return "ws" + strings.TrimPrefix(httpServer.URL, "http")
+}
+
+func (relay *fakeRelay) dials() int {
+	relay.mu.Lock()
+	defer relay.mu.Unlock()
+	return relay.dialCount
+}
+
+// recordingSleep returns a sleep func that records every backoff duration it is
+// asked to wait for and returns immediately (respecting ctx cancellation). The
+// returned getter yields a copy of the recorded schedule.
+func recordingSleep() (func(ctx context.Context, duration time.Duration) error, func() []time.Duration) {
+	var mu sync.Mutex
+	var schedule []time.Duration
+	sleep := func(ctx context.Context, duration time.Duration) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		mu.Lock()
+		schedule = append(schedule, duration)
+		mu.Unlock()
+		return nil
+	}
+	get := func() []time.Duration {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]time.Duration, len(schedule))
+		copy(out, schedule)
+		return out
+	}
+	return sleep, get
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestReconnectGivesUpAfterMaxAttempts drives a disconnect followed by a relay
+// that rejects every reconnect, and asserts the CLI exhausts maxReconnectAttempts
+// and returns a CategoryNetwork "gave up" error.
+func TestReconnectGivesUpAfterMaxAttempts(t *testing.T) {
+	relay := &fakeRelay{
+		dropAfterAssign: true,
+		rejectFrom:      2, // first dial accepted+dropped; reconnect dials rejected
+		rejectCode:      http.StatusBadGateway,
+	}
+	wsURL := newFakeRelay(t, relay)
+
+	sleep, _ := recordingSleep()
+	tun := New(wsURL, "http://localhost:0", "", discardLogger(), Callbacks{})
+	tun.sleep = sleep
+	tun.SetMaxReconnectAttempts(3)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := tun.Run(ctx)
+	if err == nil {
+		t.Fatal("expected give-up error after exhausting reconnect attempts, got nil")
+	}
+	var cliErr *display.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected CLIError, got %T: %v", err, err)
+	}
+	if cliErr.Category != display.CategoryNetwork {
+		t.Errorf("category: got %v, want CategoryNetwork", cliErr.Category)
+	}
+	if !strings.Contains(cliErr.Error(), "gave up reconnecting") {
+		t.Errorf("message: got %q, want it to mention giving up", cliErr.Error())
+	}
+}
+
+// TestReconnectBackoffSchedule asserts the exponential backoff sequence
+// (1s, 2s, 4s, ...) capped at 30s by recording the durations the reconnect
+// loop sleeps for before each retry dial.
+func TestReconnectBackoffSchedule(t *testing.T) {
+	relay := &fakeRelay{
+		dropAfterAssign: true,
+		rejectFrom:      2, // accept first dial then reject all reconnect dials
+		rejectCode:      http.StatusBadGateway,
+	}
+	wsURL := newFakeRelay(t, relay)
+
+	sleep, schedule := recordingSleep()
+	tun := New(wsURL, "http://localhost:0", "", discardLogger(), Callbacks{})
+	tun.sleep = sleep
+	tun.SetMaxReconnectAttempts(8)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_ = tun.Run(ctx) // will give up; we only care about the backoff schedule
+
+	want := []time.Duration{
+		1 * time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		16 * time.Second,
+		30 * time.Second, // 32s capped to 30s
+		30 * time.Second,
+		30 * time.Second,
+	}
+	got := schedule()
+	if len(got) != len(want) {
+		t.Fatalf("backoff schedule length: got %d (%v), want %d (%v)", len(got), got, len(want), want)
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Errorf("backoff[%d]: got %s, want %s (full schedule %v)", index, got[index], want[index], got)
+		}
+	}
+}
+
+// TestReconnectStopsOnAuthErrorMidReconnect asserts that a 401 returned by the
+// relay during a reconnect attempt short-circuits the loop: no further attempts,
+// and a CategoryAuth error is surfaced.
+func TestReconnectStopsOnAuthErrorMidReconnect(t *testing.T) {
+	relay := &fakeRelay{
+		dropAfterAssign: true,
+		rejectFrom:      2, // first dial accepted+dropped; reconnect dial returns 401
+		rejectCode:      http.StatusUnauthorized,
+	}
+	wsURL := newFakeRelay(t, relay)
+
+	sleep, _ := recordingSleep()
+	tun := New(wsURL, "http://localhost:0", "", discardLogger(), Callbacks{})
+	tun.sleep = sleep
+	tun.SetMaxReconnectAttempts(10)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := tun.Run(ctx)
+	if err == nil {
+		t.Fatal("expected auth error on 401 mid-reconnect, got nil")
+	}
+	var cliErr *display.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected CLIError, got %T: %v", err, err)
+	}
+	if cliErr.Category != display.CategoryAuth {
+		t.Errorf("category: got %v, want CategoryAuth", cliErr.Category)
+	}
+	// One initial dial + exactly one reconnect dial (the 401), then it stops.
+	if dials := relay.dials(); dials != 2 {
+		t.Errorf("dial count: got %d, want 2 (initial + one 401 reconnect, no further retries)", dials)
+	}
+}
+
+// TestReconnectStopsOnForbiddenMidReconnect asserts a 403 during reconnect is
+// also terminal: it surfaces a CategoryForbidden error and does not keep retrying.
+func TestReconnectStopsOnForbiddenMidReconnect(t *testing.T) {
+	relay := &fakeRelay{
+		dropAfterAssign: true,
+		rejectFrom:      2,
+		rejectCode:      http.StatusForbidden,
+	}
+	wsURL := newFakeRelay(t, relay)
+
+	sleep, _ := recordingSleep()
+	tun := New(wsURL, "http://localhost:0", "", discardLogger(), Callbacks{})
+	tun.sleep = sleep
+	tun.SetMaxReconnectAttempts(10)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := tun.Run(ctx)
+	if err == nil {
+		t.Fatal("expected forbidden error on 403 mid-reconnect, got nil")
+	}
+	var cliErr *display.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected CLIError, got %T: %v", err, err)
+	}
+	if cliErr.Category != display.CategoryForbidden {
+		t.Errorf("category: got %v, want CategoryForbidden", cliErr.Category)
+	}
+	if dials := relay.dials(); dials != 2 {
+		t.Errorf("dial count: got %d, want 2 (initial + one 403 reconnect, no further retries)", dials)
+	}
+}
+
+// TestReconnectSucceedsAfterDrop drives a full disconnect -> reconnect cycle
+// where the relay accepts the reconnect, and asserts OnReconnected fires and
+// the loop resumes without surfacing an error (until ctx is cancelled).
+func TestReconnectSucceedsAfterDrop(t *testing.T) {
+	var dialCount int
+	var mu sync.Mutex
+	reconnected := make(chan ReconnectInfo, 1)
+
+	httpServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		mu.Lock()
+		dialCount++
+		current := dialCount
+		mu.Unlock()
+
+		conn, err := websocket.Accept(writer, request, nil)
+		if err != nil {
+			return
+		}
+		assigned := TunnelAssigned{
+			Type:           "tunnel_assigned",
+			TunnelID:       "test-tunnel-id",
+			Subdomain:      "test-sub",
+			URL:            "https://test-sub.justtunnel.dev",
+			ReconnectToken: "reconnect-token",
+		}
+		data, _ := json.Marshal(assigned)
+		conn.Write(request.Context(), websocket.MessageText, data)
+
+		if current == 1 {
+			// Drop the first connection to trigger a reconnect.
+			conn.Close(websocket.StatusAbnormalClosure, "drop")
+			return
+		}
+		// Second (reconnect) connection: hold it open.
+		<-request.Context().Done()
+		conn.Close(websocket.StatusNormalClosure, "")
+	}))
+	t.Cleanup(httpServer.Close)
+	wsURL := "ws" + strings.TrimPrefix(httpServer.URL, "http")
+
+	sleep, schedule := recordingSleep()
+	tun := New(wsURL, "http://localhost:0", "", discardLogger(), Callbacks{
+		OnReconnected: func(info ReconnectInfo) {
+			select {
+			case reconnected <- info:
+			default:
+			}
+		},
+	})
+	tun.sleep = sleep
+	tun.SetMaxReconnectAttempts(5)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- tun.Run(ctx)
+	}()
+
+	select {
+	case info := <-reconnected:
+		if info.Subdomain != "test-sub" {
+			t.Errorf("reconnect subdomain: got %q, want test-sub", info.Subdomain)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reconnect to succeed")
+	}
+
+	// Exactly one backoff wait happened before the successful reconnect.
+	if got := schedule(); len(got) != 1 || got[0] != time.Second {
+		t.Errorf("backoff before successful reconnect: got %v, want [1s]", got)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("Run returned unexpected error after cancel: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -59,7 +59,7 @@ type Tunnel struct {
 	passwordProtected bool // set from tunnel_assigned frame
 
 	maxReconnectAttempts int
-	reconnecting         bool
+	reconnecting         bool // guarded by connMu; gates the OnConnected suppression during reconnects
 	disconnectedAt       time.Time
 
 	// sleep blocks for the given duration or until ctx is cancelled,
@@ -235,11 +235,28 @@ func (t *Tunnel) connectWithURL(ctx context.Context, dialURL string) error {
 	)
 
 	// Only fire OnConnected for the initial connection, not during reconnects.
-	if !t.reconnecting && t.callbacks.OnConnected != nil {
+	if !t.isReconnecting() && t.callbacks.OnConnected != nil {
 		t.callbacks.OnConnected(assigned.Subdomain, assigned.URL, t.localTarget, t.passwordProtected)
 	}
 
 	return nil
+}
+
+// setReconnecting updates the reconnecting flag under connMu. The flag is read
+// from connectWithURL (which can run on the reconnect goroutine) and written
+// from reconnect, so it must be synchronized to stay race-free under -race.
+func (t *Tunnel) setReconnecting(value bool) {
+	t.connMu.Lock()
+	t.reconnecting = value
+	t.connMu.Unlock()
+}
+
+// isReconnecting reports whether a reconnect is in progress, reading the flag
+// under connMu.
+func (t *Tunnel) isReconnecting() bool {
+	t.connMu.Lock()
+	defer t.connMu.Unlock()
+	return t.reconnecting
 }
 
 func (t *Tunnel) readLoop(ctx context.Context) error {
@@ -331,22 +348,27 @@ func (t *Tunnel) writeJSONTo(ctx context.Context, targetConn *websocket.Conn, v 
 	return t.conn.Write(ctx, websocket.MessageText, data)
 }
 
-// isAuthError checks if an error is an authentication/authorization failure
-// by checking if it wraps a display.CLIError with CategoryAuth.
-func isAuthError(err error) bool {
-	var cliErr *display.CLIError
-	return errors.As(err, &cliErr) && cliErr.Category == display.CategoryAuth
-}
-
-// isTerminalDialError reports whether reconnecting is futile. Auth (401)
-// won't fix itself across attempts, and Forbidden (403) policy decisions
-// won't either — keep retrying would just hammer the server.
-func isTerminalDialError(err error) bool {
+// terminalReconnectError reports whether reconnecting is futile and, if so,
+// returns the error to surface to the caller. Auth (401) won't fix itself
+// across attempts and Forbidden (403) policy decisions won't either, so we stop
+// retrying rather than hammer the server. Auth gets a reconnect-specific message
+// that points at `justtunnel auth`; everything else terminal is surfaced as-is.
+//
+// Returning the resolved error here keeps the category precedence in one place:
+// callers no longer rely on the ordering of separate auth/terminal checks.
+func terminalReconnectError(err error) (error, bool) {
 	var cliErr *display.CLIError
 	if !errors.As(err, &cliErr) {
-		return false
+		return nil, false
 	}
-	return cliErr.Category == display.CategoryAuth || cliErr.Category == display.CategoryForbidden
+	switch cliErr.Category {
+	case display.CategoryAuth:
+		return display.AuthError("authentication failed during reconnect - run 'justtunnel auth' to re-authenticate"), true
+	case display.CategoryForbidden:
+		return err, true
+	default:
+		return nil, false
+	}
 }
 
 // buildReconnectURL appends reconnect token parameters to the server URL
@@ -374,17 +396,22 @@ func (t *Tunnel) buildReconnectURL() string {
 // exponential backoff: 1s, 2s, 4s, 8s, 16s, capped at 30s.
 func (t *Tunnel) reconnect(ctx context.Context) error {
 	// Wait for in-flight requests from the old connection to finish
-	// so they don't write stale responses to the new connection.
+	// so they don't write stale responses to the new connection. Bound the
+	// wait with a cancellable timer (stopped when draining wins or ctx is
+	// cancelled) so the timer goroutine never leaks past this select.
 	drainDone := make(chan struct{})
 	go func() {
 		t.wg.Wait()
 		close(drainDone)
 	}()
+	drainTimer := time.NewTimer(5 * time.Second)
 	select {
 	case <-drainDone:
-	case <-time.After(5 * time.Second):
+	case <-ctx.Done():
+	case <-drainTimer.C:
 		t.logger.Warn("timed out waiting for in-flight requests before reconnect")
 	}
+	drainTimer.Stop()
 
 	// Close old connection before attempting to dial a new one.
 	t.connMu.Lock()
@@ -393,7 +420,7 @@ func (t *Tunnel) reconnect(ctx context.Context) error {
 	}
 	t.connMu.Unlock()
 
-	t.reconnecting = true
+	t.setReconnecting(true)
 	previousSubdomain := t.subdomain
 
 	backoff := time.Second
@@ -402,6 +429,7 @@ func (t *Tunnel) reconnect(ctx context.Context) error {
 	for attempt := 1; ; attempt++ {
 		// Check max reconnect attempts (0 = unlimited).
 		if t.maxReconnectAttempts > 0 && attempt > t.maxReconnectAttempts {
+			t.setReconnecting(false)
 			elapsed := time.Since(t.disconnectedAt).Round(time.Second)
 			return display.NetworkError(fmt.Sprintf(
 				"gave up reconnecting after %d attempts (disconnected for %s). Check your internet connection and restart the tunnel.",
@@ -414,6 +442,7 @@ func (t *Tunnel) reconnect(ctx context.Context) error {
 		}
 
 		if err := t.waitWithCountdown(ctx, attempt, backoff); err != nil {
+			t.setReconnecting(false)
 			return err
 		}
 
@@ -423,11 +452,9 @@ func (t *Tunnel) reconnect(ctx context.Context) error {
 
 			// Don't retry on auth or forbidden errors — credentials and
 			// policy decisions won't change between attempts.
-			if isAuthError(err) {
-				return display.AuthError("authentication failed during reconnect - run 'justtunnel auth' to re-authenticate")
-			}
-			if isTerminalDialError(err) {
-				return err
+			if terminalErr, terminal := terminalReconnectError(err); terminal {
+				t.setReconnecting(false)
+				return terminalErr
 			}
 
 			backoff *= 2
@@ -437,7 +464,7 @@ func (t *Tunnel) reconnect(ctx context.Context) error {
 			continue
 		}
 
-		t.reconnecting = false
+		t.setReconnecting(false)
 
 		if t.callbacks.OnReconnected != nil {
 			info := ReconnectInfo{
@@ -455,7 +482,13 @@ func (t *Tunnel) reconnect(ctx context.Context) error {
 }
 
 // waitWithCountdown waits for the given backoff duration, calling OnReconnectWait
-// every second with the remaining time.
+// once per second with the remaining time.
+//
+// Contract: the callback fires BEFORE each sleep, so the first call reports the
+// full backoff remaining (not backoff-1s as the prior ticker-based loop did) and
+// the last call reports the final sub-second step. Callers driving a UI countdown
+// should treat the reported value as the time still to wait at the moment of the
+// call.
 func (t *Tunnel) waitWithCountdown(ctx context.Context, attempt int, backoff time.Duration) error {
 	if t.callbacks.OnReconnectWait == nil {
 		return t.sleep(ctx, backoff)

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -61,6 +61,12 @@ type Tunnel struct {
 	maxReconnectAttempts int
 	reconnecting         bool
 	disconnectedAt       time.Time
+
+	// sleep blocks for the given duration or until ctx is cancelled,
+	// returning ctx.Err() in the latter case. It is a seam for tests to
+	// observe the backoff schedule and advance time without real waits.
+	// Defaults to realSleep.
+	sleep func(ctx context.Context, duration time.Duration) error
 }
 
 func New(serverURL, localTarget, authToken string, logger *slog.Logger, callbacks Callbacks) *Tunnel {
@@ -71,6 +77,19 @@ func New(serverURL, localTarget, authToken string, logger *slog.Logger, callback
 		logger:               logger,
 		callbacks:            callbacks,
 		maxReconnectAttempts: 50,
+		sleep:                realSleep,
+	}
+}
+
+// realSleep blocks for the given duration or until ctx is cancelled.
+func realSleep(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
 	}
 }
 
@@ -439,32 +458,23 @@ func (t *Tunnel) reconnect(ctx context.Context) error {
 // every second with the remaining time.
 func (t *Tunnel) waitWithCountdown(ctx context.Context, attempt int, backoff time.Duration) error {
 	if t.callbacks.OnReconnectWait == nil {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(backoff):
-			return nil
-		}
+		return t.sleep(ctx, backoff)
 	}
 
-	deadline := time.Now().Add(backoff)
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
-	for {
-		remaining := time.Until(deadline)
-		if remaining <= 0 {
-			return nil
-		}
-
+	remaining := backoff
+	for remaining > 0 {
 		t.callbacks.OnReconnectWait(attempt, remaining)
 
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
+		step := time.Second
+		if remaining < step {
+			step = remaining
 		}
+		if err := t.sleep(ctx, step); err != nil {
+			return err
+		}
+		remaining -= step
 	}
+	return nil
 }
 
 // Shutdown gracefully closes the WebSocket connection and waits for in-flight


### PR DESCRIPTION
**Problem.** reconnect() implements exponential backoff, max-attempts bound, in-flight drain timeout, and terminal-error short-circuits, but tunnel_test.go has only a happy-path test plus two dial-error mappings. No test drives a disconnect->reconnect cycle, the backoff schedule, the give-up bound, or auth-error-mid-reconnect. #132 lives in this exact code.

**Fix.** Add table-driven tests against a fake WS server that drops the connection: inject a clock to assert the backoff sequence, assert give-up after N attempts, and assert an injected 401 mid-reconnect stops retrying.

**Where.** justtunnel-cli/internal/tunnel/tunnel.go:356

Closes #60
