### PR TITLE
worker rm (local-only) leaves the supervisor service registered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build
         run: go build ./...
 
-      - name: Lint
+      - name: Vet
         run: go vet ./...
 
       - name: Test

--- a/cmd/worker_rm.go
+++ b/cmd/worker_rm.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/spf13/cobra"
 
@@ -46,7 +47,8 @@ func runWorkerRm(cmd *cobra.Command, args []string) error {
 		// config" line. Idempotent success is still success — `rm` of a
 		// non-existent thing is a no-op success in Unix — but we owe the
 		// user an honest message.
-		if _, readErr := worker.Read(name); errors.Is(readErr, os.ErrNotExist) {
+		cfg, readErr := worker.Read(name)
+		if errors.Is(readErr, os.ErrNotExist) {
 			fmt.Fprintf(cmd.OutOrStdout(),
 				"No local config found for %q.\n", name,
 			)
@@ -55,9 +57,20 @@ func runWorkerRm(cmd *cobra.Command, args []string) error {
 		// Read may also fail with non-ENOENT errors (permissions, parse
 		// failure). In that case still try to delete so the user has a
 		// path forward; surface the read error only if delete also fails.
+		// cfg is nil on a non-ENOENT read failure, so the service-teardown
+		// step below short-circuits — we can't know the backend.
 		if err := worker.Delete(name); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("delete local worker config: %w", err)
 		}
+		// If the config recorded a managed supervisor (launchd/systemd),
+		// deleting only the config would orphan the service unit — a ghost
+		// launchd/systemd job keeps firing on login/boot, now reading a
+		// config that no longer exists. Best-effort tear it down so
+		// local-only `rm` leaves no residue. Unbootstrap is idempotent
+		// (a missing unit is a no-op), and any failure is surfaced as a
+		// warning with a `worker uninstall` pointer rather than failing the
+		// command — the config is already gone and the user wants cleanup.
+		teardownLocalService(cmd, cfg, name)
 		fmt.Fprintf(cmd.OutOrStdout(),
 			"Removed local config for %q. The worker may still be registered server-side.\n"+
 				"Use --delete-on-server to also delete server-side.\n",
@@ -140,4 +153,47 @@ func runWorkerRm(cmd *cobra.Command, args []string) error {
 		)
 	}
 	return nil
+}
+
+// teardownLocalService best-effort removes the platform service unit that
+// `worker install` registered for this worker. It runs only when the config
+// recorded a real managed backend (launchd/systemd) — configs with
+// ServiceBackend "none"/""/"unsupported" never registered a unit, so there
+// is nothing to tear down.
+//
+// This is intentionally non-fatal: the local config is already deleted by the
+// time we get here and the operator's intent is cleanup, so a teardown failure
+// is downgraded to a stderr warning that points at `worker uninstall` (which
+// has --force for stubborn cases) rather than failing the command.
+func teardownLocalService(cmd *cobra.Command, cfg *worker.Config, name string) {
+	if cfg == nil {
+		return
+	}
+	switch cfg.ServiceBackend {
+	case "launchd", "systemd":
+		// managed backend — fall through to teardown.
+	default:
+		// "none", "", or "unsupported": no service unit was ever
+		// registered, so there is nothing to remove.
+		return
+	}
+
+	svc, err := newServiceInstaller(runtime.GOOS)
+	if err != nil {
+		// No supervisor adapter for this OS (e.g. the config was created
+		// on another platform). Point the user at uninstall on the matching
+		// host and move on.
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"warning: worker %q recorded a %s service but this host (%s) has no supervisor to remove it; run `justtunnel worker uninstall %s` on the original machine\n",
+			name, cfg.ServiceBackend, runtime.GOOS, name,
+		)
+		return
+	}
+	if unbootErr := svc.Unbootstrap(cmd.Context(), name); unbootErr != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"warning: removed local config but could not stop the %s service for %q: %v\n"+
+				"run `justtunnel worker uninstall %s --force` to finish removing the service unit\n",
+			cfg.ServiceBackend, name, unbootErr, name,
+		)
+	}
 }

--- a/cmd/worker_rm.go
+++ b/cmd/worker_rm.go
@@ -1,15 +1,23 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/justtunnel/justtunnel-cli/internal/worker"
 )
+
+// serviceTeardownTimeout bounds the best-effort supervisor Unbootstrap call
+// in teardownLocalService. The teardown runs on a context detached from the
+// caller's deadline (see teardownLocalService) so it gets its own budget
+// rather than inheriting an already-fired deadline from the main operation.
+const serviceTeardownTimeout = 10 * time.Second
 
 // workerRmDeleteOnServer is the bound flag value for `worker rm
 // --delete-on-server`. Cobra does NOT reset bound flag values between
@@ -58,7 +66,16 @@ func runWorkerRm(cmd *cobra.Command, args []string) error {
 		// failure). In that case still try to delete so the user has a
 		// path forward; surface the read error only if delete also fails.
 		// cfg is nil on a non-ENOENT read failure, so the service-teardown
-		// step below short-circuits — we can't know the backend.
+		// step below short-circuits — we can't know the backend. Warn so the
+		// operator knows a possibly-registered unit was NOT torn down and
+		// has a path to remove it (uninstall --force doesn't read the config).
+		if readErr != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"warning: could not read local config for %q (%v); if a service unit was installed it was NOT removed.\n"+
+					"run `justtunnel worker uninstall %s --force` to remove any orphaned service unit.\n",
+				name, readErr, name,
+			)
+		}
 		if err := worker.Delete(name); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("delete local worker config: %w", err)
 		}
@@ -110,6 +127,20 @@ func runWorkerRm(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Read the local config before deleting it so we can tear down any
+	// managed service unit afterward (same ghost-unit concern as the
+	// local-only path). A non-ENOENT read failure leaves workerCfg nil, in
+	// which case teardownLocalService short-circuits; warn the operator so
+	// a possibly-orphaned unit doesn't disappear silently.
+	workerCfg, cfgReadErr := worker.Read(name)
+	if cfgReadErr != nil && !errors.Is(cfgReadErr, os.ErrNotExist) {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"warning: could not read local config for %q (%v); if a service unit was installed it was NOT removed.\n"+
+				"run `justtunnel worker uninstall %s --force` to remove any orphaned service unit.\n",
+			name, cfgReadErr, name,
+		)
+	}
+
 	if workerID == "" {
 		// Server doesn't know about it — treat as already-deleted and
 		// proceed with local cleanup so the user can recover from
@@ -117,6 +148,7 @@ func runWorkerRm(cmd *cobra.Command, args []string) error {
 		if err := worker.Delete(name); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("delete local worker config: %w", err)
 		}
+		teardownLocalService(cmd, workerCfg, name)
 		fmt.Fprintf(cmd.OutOrStdout(),
 			"Worker %q not found server-side; removed local config.\n", name,
 		)
@@ -132,6 +164,7 @@ func runWorkerRm(cmd *cobra.Command, args []string) error {
 	if err := worker.Delete(name); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("delete local worker config: %w", err)
 	}
+	teardownLocalService(cmd, workerCfg, name)
 
 	if notFound {
 		// 404 here means the server lost track of the ID between our
@@ -169,12 +202,9 @@ func teardownLocalService(cmd *cobra.Command, cfg *worker.Config, name string) {
 	if cfg == nil {
 		return
 	}
-	switch cfg.ServiceBackend {
-	case "launchd", "systemd":
-		// managed backend — fall through to teardown.
-	default:
-		// "none", "", or "unsupported": no service unit was ever
-		// registered, so there is nothing to remove.
+	// Only launchd/systemd configs ever registered a unit. "none", "",
+	// or "unsupported" backends have nothing to remove.
+	if cfg.ServiceBackend != "launchd" && cfg.ServiceBackend != "systemd" {
 		return
 	}
 
@@ -189,7 +219,14 @@ func teardownLocalService(cmd *cobra.Command, cfg *worker.Config, name string) {
 		)
 		return
 	}
-	if unbootErr := svc.Unbootstrap(cmd.Context(), name); unbootErr != nil {
+	// Detach from the caller's context for the teardown. The config is
+	// already deleted by the time we get here, so a deadline/cancel on the
+	// main operation (e.g. a scripted `rm` with a timeout that fires
+	// between Delete and here) must NOT abort cleanup and leave the unit
+	// orphaned. We give the supervisor call its own short budget.
+	teardownCtx, cancel := context.WithTimeout(context.WithoutCancel(cmd.Context()), serviceTeardownTimeout)
+	defer cancel()
+	if unbootErr := svc.Unbootstrap(teardownCtx, name); unbootErr != nil {
 		fmt.Fprintf(cmd.ErrOrStderr(),
 			"warning: removed local config but could not stop the %s service for %q: %v\n"+
 				"run `justtunnel worker uninstall %s --force` to finish removing the service unit\n",

--- a/cmd/worker_test.go
+++ b/cmd/worker_test.go
@@ -507,6 +507,104 @@ func TestWorkerRmLocalOnlyMissingConfigIsIdempotent(t *testing.T) {
 	}
 }
 
+// TestWorkerRmLocalOnlyManagedBackendTearsDownService covers CLI-7: when
+// the local config records a managed supervisor (launchd/systemd), a
+// local-only `rm` must tear down the service unit too — otherwise a ghost
+// launchd/systemd job keeps firing on boot reading a now-deleted config.
+func TestWorkerRmLocalOnlyManagedBackendTearsDownService(t *testing.T) {
+	var httpCalls int32
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&httpCalls, 1)
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer stub.Close()
+
+	resetWorkerState(t, teamCfg(stub.URL))
+
+	if err := worker.Write(&worker.Config{
+		WorkerID: "wkr_x", Name: "alice", Context: "team:team-alpha", ServiceBackend: "launchd",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	fake := &fakeServiceInstaller{}
+	withFakeInstaller(t, fake)
+
+	out, err := runCmd(t, "worker", "rm", "alice")
+	if err != nil {
+		t.Fatalf("rm: %v", err)
+	}
+	if got := atomic.LoadInt32(&fake.unbootstrapCalls); got != 1 {
+		t.Errorf("Unbootstrap calls: got %d, want 1 (service unit must be removed)", got)
+	}
+	if got := fake.readGotUnbootName(); got != "alice" {
+		t.Errorf("Unbootstrap name: got %q, want alice", got)
+	}
+	if atomic.LoadInt32(&httpCalls) != 0 {
+		t.Errorf("local-only rm must not call the server, got %d calls", httpCalls)
+	}
+	if _, readErr := worker.Read("alice"); !errors.Is(readErr, os.ErrNotExist) {
+		t.Errorf("local config should be gone, got err=%v", readErr)
+	}
+	if !strings.Contains(out, "Removed local config") {
+		t.Errorf("expected success message, got: %s", out)
+	}
+}
+
+// TestWorkerRmLocalOnlyNoneBackendSkipsTeardown verifies the guard: a config
+// with ServiceBackend "none" never registered a service unit, so a local-only
+// `rm` must NOT invoke the supervisor.
+func TestWorkerRmLocalOnlyNoneBackendSkipsTeardown(t *testing.T) {
+	resetWorkerState(t, teamCfg("http://unused.invalid"))
+
+	if err := worker.Write(&worker.Config{
+		WorkerID: "wkr_x", Name: "alice", Context: "team:team-alpha", ServiceBackend: "none",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	fake := &fakeServiceInstaller{}
+	withFakeInstaller(t, fake)
+
+	if _, err := runCmd(t, "worker", "rm", "alice"); err != nil {
+		t.Fatalf("rm: %v", err)
+	}
+	if got := atomic.LoadInt32(&fake.unbootstrapCalls); got != 0 {
+		t.Errorf("Unbootstrap must NOT run for ServiceBackend=none, got %d calls", got)
+	}
+}
+
+// TestWorkerRmLocalOnlyTeardownFailureIsBestEffort verifies CLI-7's
+// best-effort contract: an Unbootstrap failure must NOT fail the command (the
+// config is already gone) — it warns on stderr and points at `worker
+// uninstall --force`.
+func TestWorkerRmLocalOnlyTeardownFailureIsBestEffort(t *testing.T) {
+	resetWorkerState(t, teamCfg("http://unused.invalid"))
+
+	if err := worker.Write(&worker.Config{
+		WorkerID: "wkr_x", Name: "alice", Context: "team:team-alpha", ServiceBackend: "systemd",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	fake := &fakeServiceInstaller{unbootstrapErr: errors.New("systemctl boom")}
+	withFakeInstaller(t, fake)
+
+	stdout, stderr, err := runCmdSplit(t, "worker", "rm", "alice")
+	if err != nil {
+		t.Fatalf("rm must succeed despite teardown failure, got err=%v", err)
+	}
+	if _, readErr := worker.Read("alice"); !errors.Is(readErr, os.ErrNotExist) {
+		t.Errorf("local config should still be deleted, got err=%v", readErr)
+	}
+	if !strings.Contains(stdout, "Removed local config") {
+		t.Errorf("expected success message on stdout, got: %s", stdout)
+	}
+	if !strings.Contains(stderr, "worker uninstall") {
+		t.Errorf("expected stderr warning pointing at `worker uninstall`, got: %s", stderr)
+	}
+}
+
 // TestWorkerCreateRollsBackOnLocalWriteFailure covers blocker #2 happy
 // rollback: local worker.Write fails, compensating DELETE succeeds. The
 // CLI must surface a "rolled back, please retry" error.

--- a/cmd/worker_test.go
+++ b/cmd/worker_test.go
@@ -369,6 +369,91 @@ func TestWorkerRmDeleteOnServerHappyPath(t *testing.T) {
 	}
 }
 
+// TestWorkerRmDeleteOnServerTearsDownManagedService covers the CLI-7 gap on
+// the --delete-on-server path: after the server-side DELETE and local config
+// removal, a managed-backend worker's service unit must also be torn down —
+// otherwise `rm --delete-on-server` orphans the launchd/systemd unit just
+// like the local-only path used to.
+func TestWorkerRmDeleteOnServerTearsDownManagedService(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method == http.MethodGet && request.URL.Path == "/api/teams/team-alpha/workers" {
+			writer.Header().Set("Content-Type", "application/json")
+			writer.Write([]byte(`{"workers":[{"id":"wkr_x","name":"alice","team_id":"team-alpha"}]}`))
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(`{"status":"deleted"}`))
+	}))
+	defer stub.Close()
+
+	resetWorkerState(t, teamCfg(stub.URL))
+
+	if err := worker.Write(&worker.Config{
+		WorkerID: "wkr_x", Name: "alice", Context: "team:team-alpha", ServiceBackend: "launchd",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	fake := &fakeServiceInstaller{}
+	withFakeInstaller(t, fake)
+
+	if _, err := runCmd(t, "worker", "rm", "alice", "--delete-on-server"); err != nil {
+		t.Fatalf("rm: %v", err)
+	}
+	if got := atomic.LoadInt32(&fake.unbootstrapCalls); got != 1 {
+		t.Errorf("Unbootstrap calls: got %d, want 1 (service unit must be removed on --delete-on-server too)", got)
+	}
+	if got := fake.readGotUnbootName(); got != "alice" {
+		t.Errorf("Unbootstrap name: got %q, want alice", got)
+	}
+	if _, readErr := worker.Read("alice"); !errors.Is(readErr, os.ErrNotExist) {
+		t.Errorf("local config should be gone, got err=%v", readErr)
+	}
+}
+
+// TestWorkerRmDeleteOnServerNotFoundTearsDownManagedService covers the
+// "server doesn't know about it" sub-path of --delete-on-server: even when
+// the worker is absent server-side, the managed service unit recorded in the
+// local config must still be torn down.
+func TestWorkerRmDeleteOnServerNotFoundTearsDownManagedService(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method == http.MethodGet {
+			writer.Header().Set("Content-Type", "application/json")
+			writer.Write([]byte(`{"workers":[]}`))
+			return
+		}
+		t.Errorf("unexpected %s to %s; worker is absent server-side so no DELETE should fire", request.Method, request.URL.Path)
+		http.NotFound(writer, request)
+	}))
+	defer stub.Close()
+
+	resetWorkerState(t, teamCfg(stub.URL))
+
+	if err := worker.Write(&worker.Config{
+		WorkerID: "wkr_x", Name: "alice", Context: "team:team-alpha", ServiceBackend: "systemd",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	fake := &fakeServiceInstaller{}
+	withFakeInstaller(t, fake)
+
+	out, err := runCmd(t, "worker", "rm", "alice", "--delete-on-server")
+	if err != nil {
+		t.Fatalf("rm: %v", err)
+	}
+	if got := atomic.LoadInt32(&fake.unbootstrapCalls); got != 1 {
+		t.Errorf("Unbootstrap calls: got %d, want 1 (unit must be removed even when server-side absent)", got)
+	}
+	if _, readErr := worker.Read("alice"); !errors.Is(readErr, os.ErrNotExist) {
+		t.Errorf("local config should be gone, got err=%v", readErr)
+	}
+	if !strings.Contains(out, "not found server-side") {
+		t.Errorf("expected not-found message, got: %s", out)
+	}
+}
+
 func TestWorkerRmDeleteOnServer404ProceedsLocally(t *testing.T) {
 	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.Method == http.MethodGet {
@@ -507,19 +592,57 @@ func TestWorkerRmLocalOnlyMissingConfigIsIdempotent(t *testing.T) {
 	}
 }
 
+// TestWorkerRmLocalOnlyCorruptConfigWarnsAboutOrphanedUnit covers the
+// non-ENOENT read-failure branch: when the config is unreadable (malformed
+// JSON), rm still deletes the file but cannot know the backend, so any
+// installed service unit would be silently orphaned. The command must warn
+// and point the operator at `worker uninstall --force`.
+func TestWorkerRmLocalOnlyCorruptConfigWarnsAboutOrphanedUnit(t *testing.T) {
+	resetWorkerState(t, teamCfg("http://unused.invalid"))
+
+	// Write a malformed JSON file at the config path so worker.Read fails
+	// with a parse error (non-ENOENT). resetWorkerState sets JUSTTUNNEL_HOME
+	// to a temp dir; configs live under workers/<name>.json.
+	workersDir := os.Getenv("JUSTTUNNEL_HOME") + "/workers"
+	if err := os.MkdirAll(workersDir, 0o700); err != nil {
+		t.Fatalf("mkdir workers: %v", err)
+	}
+	if err := os.WriteFile(workersDir+"/alice.json", []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("seed corrupt config: %v", err)
+	}
+
+	fake := &fakeServiceInstaller{}
+	withFakeInstaller(t, fake)
+
+	stdout, stderr, err := runCmdSplit(t, "worker", "rm", "alice")
+	if err != nil {
+		t.Fatalf("rm must succeed despite corrupt config, got err=%v", err)
+	}
+	// cfg is nil on a parse failure, so teardown short-circuits — no
+	// supervisor call should happen.
+	if got := atomic.LoadInt32(&fake.unbootstrapCalls); got != 0 {
+		t.Errorf("Unbootstrap must not run when config is unreadable, got %d calls", got)
+	}
+	if _, readErr := worker.Read("alice"); !errors.Is(readErr, os.ErrNotExist) {
+		t.Errorf("corrupt config should still be deleted, got err=%v", readErr)
+	}
+	if !strings.Contains(stdout, "Removed local config") {
+		t.Errorf("expected success message on stdout, got: %s", stdout)
+	}
+	if !strings.Contains(stderr, "worker uninstall") || !strings.Contains(stderr, "--force") {
+		t.Errorf("expected stderr warning pointing at `worker uninstall --force`, got: %s", stderr)
+	}
+}
+
 // TestWorkerRmLocalOnlyManagedBackendTearsDownService covers CLI-7: when
 // the local config records a managed supervisor (launchd/systemd), a
 // local-only `rm` must tear down the service unit too — otherwise a ghost
 // launchd/systemd job keeps firing on boot reading a now-deleted config.
 func TestWorkerRmLocalOnlyManagedBackendTearsDownService(t *testing.T) {
-	var httpCalls int32
-	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt32(&httpCalls, 1)
-		writer.WriteHeader(http.StatusOK)
-	}))
-	defer stub.Close()
-
-	resetWorkerState(t, teamCfg(stub.URL))
+	// Point at an unreachable host: a local-only rm must never make an HTTP
+	// call, so any accidental request fails loudly instead of silently
+	// returning a stub 200.
+	resetWorkerState(t, teamCfg("http://unused.invalid"))
 
 	if err := worker.Write(&worker.Config{
 		WorkerID: "wkr_x", Name: "alice", Context: "team:team-alpha", ServiceBackend: "launchd",
@@ -540,14 +663,46 @@ func TestWorkerRmLocalOnlyManagedBackendTearsDownService(t *testing.T) {
 	if got := fake.readGotUnbootName(); got != "alice" {
 		t.Errorf("Unbootstrap name: got %q, want alice", got)
 	}
-	if atomic.LoadInt32(&httpCalls) != 0 {
-		t.Errorf("local-only rm must not call the server, got %d calls", httpCalls)
-	}
 	if _, readErr := worker.Read("alice"); !errors.Is(readErr, os.ErrNotExist) {
 		t.Errorf("local config should be gone, got err=%v", readErr)
 	}
 	if !strings.Contains(out, "Removed local config") {
 		t.Errorf("expected success message, got: %s", out)
+	}
+}
+
+// TestWorkerRmLocalOnlyManagedBackendUnsupportedOSWarns covers the
+// no-supervisor branch in teardownLocalService: when the config records a
+// managed backend (launchd/systemd) but the host has no supervisor adapter
+// (e.g. a config copied from darwin and rm'd on Windows), rm must still
+// succeed, attempt no Unbootstrap, and warn the operator to run uninstall on
+// the original machine.
+func TestWorkerRmLocalOnlyManagedBackendUnsupportedOSWarns(t *testing.T) {
+	resetWorkerState(t, teamCfg("http://unused.invalid"))
+
+	if err := worker.Write(&worker.Config{
+		WorkerID: "wkr_x", Name: "alice", Context: "team:team-alpha", ServiceBackend: "launchd",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	withUnsupportedOS(t)
+
+	stdout, stderr, err := runCmdSplit(t, "worker", "rm", "alice")
+	if err != nil {
+		t.Fatalf("rm must succeed on unsupported OS, got err=%v", err)
+	}
+	if _, readErr := worker.Read("alice"); !errors.Is(readErr, os.ErrNotExist) {
+		t.Errorf("local config should be gone, got err=%v", readErr)
+	}
+	if !strings.Contains(stdout, "Removed local config") {
+		t.Errorf("expected success message on stdout, got: %s", stdout)
+	}
+	if !strings.Contains(stderr, "original machine") {
+		t.Errorf("expected stderr warning pointing at the original machine, got: %s", stderr)
+	}
+	if !strings.Contains(stderr, "worker uninstall") {
+		t.Errorf("expected stderr warning to mention `worker uninstall`, got: %s", stderr)
 	}
 }
 


### PR DESCRIPTION
**Problem.** The local-only path deletes the config but never calls Unbootstrap, so a ghost launchd/systemd unit keeps firing on login/boot reading a now-deleted config. The success message warns about server-side registration but not the service unit, even though ServiceBackend is in the config it just read.

**Fix.** When the config's ServiceBackend is not 'none', either best-effort call Unbootstrap or add a success-message line directing the user to run 'worker uninstall'.

**Where.** justtunnel-cli/cmd/worker_rm.go:37

Closes #67
