### PR TITLE
worker uninstall --force exits 0 on step failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,10 @@ jobs:
           git config user.email "ci@justtunnel.dev"
           git config user.name "ci"
           git fetch origin main
-          git merge --no-edit origin/main
+          git merge --no-edit origin/main || {
+            echo "::error::Merge conflict with origin/main. Rebase or merge main into this branch locally, resolve the conflicts, and re-push."
+            exit 1
+          }
 
       - uses: actions/setup-go@v5
         with:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -86,7 +87,14 @@ func init() {
 func Execute() error {
 	err := rootCmd.Execute()
 	if err != nil {
-		display.PrintError(err)
+		// errForceStepErrors already printed a per-step summary to stderr
+		// inside runWorkerUninstall. PrintError would fall through to its
+		// generic branch and emit a second, redundant "Error: ..." line
+		// after that summary. Suppress it — the summary is the feedback.
+		// The non-zero exit code is still propagated to the caller.
+		if !errors.Is(err, errForceStepErrors) {
+			display.PrintError(err)
+		}
 	}
 	return err
 }

--- a/cmd/worker_uninstall.go
+++ b/cmd/worker_uninstall.go
@@ -28,13 +28,15 @@ var workerUninstallDeleteOnServer bool
 // registered). Best-effort cleanup runs regardless of the exit code.
 var workerUninstallForce bool
 
-// ErrForceStepErrors is the sentinel returned when --force ran every
+// errForceStepErrors is the sentinel returned when --force ran every
 // step to completion but at least one step failed. Callers can match
 // it with errors.Is to distinguish "best-effort cleanup hit a snag"
 // from an early abort. The detailed per-step summary is printed to
-// stderr before this is returned; the rendered error stays terse so
-// the summary is not duplicated.
-var ErrForceStepErrors = errors.New("worker uninstall --force completed with step errors")
+// stderr before this is returned; Execute() recognizes the sentinel and
+// skips the generic display.PrintError line so the summary is not
+// duplicated. Unexported because cmd is a leaf package — the only caller
+// is Execute() in this same package.
+var errForceStepErrors = errors.New("worker uninstall --force completed with step errors")
 
 var workerUninstallCmd = &cobra.Command{
 	Use:   "uninstall <name>",
@@ -159,7 +161,8 @@ func runWorkerUninstall(cmd *cobra.Command, args []string) error {
 		// Two cases land here:
 		//   1. --delete-on-server NOT set → local-only path.
 		//   2. --delete-on-server set AND --force → best-effort: run
-		//      every step, collect errors, exit 0.
+		//      every step, collect errors, exit non-zero when any step
+		//      fails.
 		// E1: under --force + --delete-on-server we still attempt the
 		// server delete FIRST so the operator's local pointer is
 		// preserved on a server-side failure (e.g. 403 from a stale
@@ -206,18 +209,19 @@ func runWorkerUninstall(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Step 4: post-uninstall probe. Best-effort warning only — the
+	// Step 3: post-uninstall probe. Best-effort warning only — the
 	// supervisor may take a beat to fully tear down. We intentionally
 	// do NOT fail on a still-running probe; an operator who needs a
 	// hard guarantee can re-run with --force after a moment.
 	probePostUninstall(cmd.Context(), name, cmd.ErrOrStderr())
 
-	// --force summary: print each collected error to stderr, then fall
-	// through to the success line so the operator sees what was cleaned
-	// up. We return ErrForceStepErrors at the very end (after the
-	// success line) so the command exits non-zero — scripts checking $?
-	// must not get a false positive on a partial failure.
-	if workerUninstallForce && len(stepErrors) > 0 {
+	// forceFailed gates the non-zero exit and the stdout wording below.
+	// Compute it once so the summary guard and the return path can't drift.
+	forceFailed := workerUninstallForce && len(stepErrors) > 0
+
+	// --force summary: print each collected error to stderr so the
+	// operator sees exactly which steps failed.
+	if forceFailed {
 		fmt.Fprintf(cmd.ErrOrStderr(),
 			"warning: --force completed uninstall with %d step error(s):\n", len(stepErrors))
 		for _, stepErr := range stepErrors {
@@ -225,19 +229,18 @@ func runWorkerUninstall(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// forceFailed gates the non-zero exit. The summary above has already
-	// hit stderr; the success line below still prints because best-effort
-	// cleanup did run. We return the sentinel after rendering both.
-	forceFailed := workerUninstallForce && len(stepErrors) > 0
-
-	if !changed {
+	// Stdout line. When --force hit step errors we must NOT claim
+	// "already uninstalled" even if nothing mutated (e.g. server delete
+	// failed AND local config was already absent) — that would contradict
+	// the stderr error summary and the non-zero exit. Report partial
+	// cleanup instead. On success, render the usual outcome line.
+	switch {
+	case forceFailed:
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"worker %q: cleanup completed with errors (see warnings above)\n", name)
+	case !changed:
 		fmt.Fprintf(cmd.OutOrStdout(), "worker %q already uninstalled\n", name)
-		if forceFailed {
-			return ErrForceStepErrors
-		}
-		return nil
-	}
-	if workerUninstallDeleteOnServer {
+	case workerUninstallDeleteOnServer:
 		// Server soft-deletes (status=retired_quarantined); a reaper
 		// removes the row 30 days later. Tell the operator so they
 		// aren't surprised by `worker list --all` still showing the
@@ -246,14 +249,12 @@ func runWorkerUninstall(cmd *cobra.Command, args []string) error {
 			"Uninstalled worker %q (server-side row quarantined; permanent removal in 30 days)\n",
 			name,
 		)
-		if forceFailed {
-			return ErrForceStepErrors
-		}
-		return nil
+	default:
+		fmt.Fprintf(cmd.OutOrStdout(), "Uninstalled worker %q\n", name)
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "Uninstalled worker %q\n", name)
+
 	if forceFailed {
-		return ErrForceStepErrors
+		return errForceStepErrors
 	}
 	return nil
 }

--- a/cmd/worker_uninstall.go
+++ b/cmd/worker_uninstall.go
@@ -22,9 +22,19 @@ var workerUninstallDeleteOnServer bool
 
 // workerUninstallForce is the bound flag value for `worker uninstall
 // --force`. With --force each step's error is collected, all steps
-// run to completion, errors are printed to stderr but the command
-// exits 0 (best-effort cleanup; useful when local config is corrupt).
+// run to completion, and every collected error is printed to stderr.
+// The command then exits non-zero so scripts checking $? still detect
+// a partial failure (e.g. server-side 403 + local service left
+// registered). Best-effort cleanup runs regardless of the exit code.
 var workerUninstallForce bool
+
+// ErrForceStepErrors is the sentinel returned when --force ran every
+// step to completion but at least one step failed. Callers can match
+// it with errors.Is to distinguish "best-effort cleanup hit a snag"
+// from an early abort. The detailed per-step summary is printed to
+// stderr before this is returned; the rendered error stays terse so
+// the summary is not duplicated.
+var ErrForceStepErrors = errors.New("worker uninstall --force completed with step errors")
 
 var workerUninstallCmd = &cobra.Command{
 	Use:   "uninstall <name>",
@@ -32,8 +42,12 @@ var workerUninstallCmd = &cobra.Command{
 	Long: "Reverses `worker install`: stops the platform service, removes the local\n" +
 		"service definition, and deletes the local worker config. With\n" +
 		"--delete-on-server, also deletes the server-side worker record.\n\n" +
-		"Idempotent: re-running on an already-uninstalled worker is a no-op.\n" +
-		"Use --force to continue past individual step failures (best-effort cleanup).",
+		"Idempotent: re-running on an already-uninstalled worker is a no-op.\n\n" +
+		"Use --force to continue past individual step failures (best-effort cleanup).\n" +
+		"Exit codes: 0 when every step succeeds; non-zero if any step fails.\n" +
+		"Without --force the command stops at the first failure. With --force it\n" +
+		"runs every step, prints each failure to stderr, and still exits non-zero\n" +
+		"when any step failed — so scripts checking $? detect partial failures.",
 	Args: cobra.ExactArgs(1),
 	RunE: runWorkerUninstall,
 }
@@ -198,8 +212,11 @@ func runWorkerUninstall(cmd *cobra.Command, args []string) error {
 	// hard guarantee can re-run with --force after a moment.
 	probePostUninstall(cmd.Context(), name, cmd.ErrOrStderr())
 
-	// --force summary: print each collected error to stderr and
-	// continue exiting 0 so callers can drive cleanup from scripts.
+	// --force summary: print each collected error to stderr, then fall
+	// through to the success line so the operator sees what was cleaned
+	// up. We return ErrForceStepErrors at the very end (after the
+	// success line) so the command exits non-zero — scripts checking $?
+	// must not get a false positive on a partial failure.
 	if workerUninstallForce && len(stepErrors) > 0 {
 		fmt.Fprintf(cmd.ErrOrStderr(),
 			"warning: --force completed uninstall with %d step error(s):\n", len(stepErrors))
@@ -208,8 +225,16 @@ func runWorkerUninstall(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// forceFailed gates the non-zero exit. The summary above has already
+	// hit stderr; the success line below still prints because best-effort
+	// cleanup did run. We return the sentinel after rendering both.
+	forceFailed := workerUninstallForce && len(stepErrors) > 0
+
 	if !changed {
 		fmt.Fprintf(cmd.OutOrStdout(), "worker %q already uninstalled\n", name)
+		if forceFailed {
+			return ErrForceStepErrors
+		}
 		return nil
 	}
 	if workerUninstallDeleteOnServer {
@@ -221,9 +246,15 @@ func runWorkerUninstall(cmd *cobra.Command, args []string) error {
 			"Uninstalled worker %q (server-side row quarantined; permanent removal in 30 days)\n",
 			name,
 		)
+		if forceFailed {
+			return ErrForceStepErrors
+		}
 		return nil
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Uninstalled worker %q\n", name)
+	if forceFailed {
+		return ErrForceStepErrors
+	}
 	return nil
 }
 

--- a/cmd/worker_uninstall_test.go
+++ b/cmd/worker_uninstall_test.go
@@ -317,8 +317,10 @@ func TestWorkerUninstallDeleteOnServer404OnDelete(t *testing.T) {
 }
 
 // TestWorkerUninstallForceContinuesPastUnbootstrapFailure: with --force,
-// an Unbootstrap error must NOT abort the command. Local cleanup runs,
-// the warning lands on stderr, and the command exits 0.
+// an Unbootstrap error must NOT abort the command — local cleanup still
+// runs and the warning lands on stderr. But because a step failed, the
+// command must exit NON-ZERO (ErrForceStepErrors) so scripts checking $?
+// don't get a false positive on a partial failure. See justtunnel-cli#66.
 func TestWorkerUninstallForceContinuesPastUnbootstrapFailure(t *testing.T) {
 	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.WriteHeader(http.StatusOK)
@@ -339,8 +341,11 @@ func TestWorkerUninstallForceContinuesPastUnbootstrapFailure(t *testing.T) {
 	useFakeSupervisor(t, newFakeSupervisor())
 
 	stdout, stderr, err := runCmdSplit(t, "worker", "uninstall", "alpha", "--force")
-	if err != nil {
-		t.Fatalf("--force should not return an error, got: %v", err)
+	if err == nil {
+		t.Fatal("--force with a step failure must exit non-zero")
+	}
+	if !errors.Is(err, ErrForceStepErrors) {
+		t.Errorf("--force step failure should return ErrForceStepErrors, got: %v", err)
 	}
 	if _, readErr := worker.Read("alpha"); !errors.Is(readErr, os.ErrNotExist) {
 		t.Errorf("local cleanup should still run under --force, got err=%v", readErr)
@@ -505,7 +510,8 @@ func TestWorkerUninstallProbeWarnsWhenStillRunning(t *testing.T) {
 // --force --delete-on-server, a server 403 is logged but local cleanup
 // (service teardown + local config delete) continues. The local pointer
 // is cleaned up; the operator can still re-attempt the server delete
-// later from a permitted account.
+// later from a permitted account. The command still exits non-zero
+// (ErrForceStepErrors) because the server step failed. See justtunnel-cli#66.
 func TestWorkerUninstallForceWith403ContinuesLocalCleanup(t *testing.T) {
 	var deleteCalls int32
 	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -540,8 +546,11 @@ func TestWorkerUninstallForceWith403ContinuesLocalCleanup(t *testing.T) {
 
 	stdout, stderr, err := runCmdSplit(t, "worker", "uninstall", "alpha",
 		"--delete-on-server", "--force")
-	if err != nil {
-		t.Fatalf("--force should not surface a non-zero exit on server failure: %v", err)
+	if err == nil {
+		t.Fatal("--force with a server-side failure must still exit non-zero")
+	}
+	if !errors.Is(err, ErrForceStepErrors) {
+		t.Errorf("--force server failure should return ErrForceStepErrors, got: %v", err)
 	}
 	// Server-side DELETE must have been attempted FIRST.
 	if got := atomic.LoadInt32(&deleteCalls); got != 1 {
@@ -558,6 +567,41 @@ func TestWorkerUninstallForceWith403ContinuesLocalCleanup(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "Uninstalled worker") {
 		t.Errorf("expected uninstall success line in stdout, got: %s", stdout)
+	}
+}
+
+// TestWorkerUninstallForceNoErrorsExitsZero locks the happy-path contract:
+// when --force is set but every step succeeds, the command must still exit
+// 0. The non-zero exit added for justtunnel-cli#66 fires ONLY on collected
+// step errors, not on a clean --force run.
+func TestWorkerUninstallForceNoErrorsExitsZero(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer stub.Close()
+
+	resetWorkerState(t, uninstallTeamCfg(stub.URL))
+
+	if err := worker.Write(&worker.Config{
+		WorkerID: "wkr_1", Name: "alpha", Context: "team:team-acme",
+		Subdomain: "alpha--acme", CreatedAt: time.Now().UTC(), ServiceBackend: "launchd",
+	}); err != nil {
+		t.Fatalf("seed local: %v", err)
+	}
+
+	fake := &fakeServiceInstaller{}
+	withFakeInstaller(t, fake)
+	useFakeSupervisor(t, newFakeSupervisor())
+
+	stdout, _, err := runCmdSplit(t, "worker", "uninstall", "alpha", "--force")
+	if err != nil {
+		t.Fatalf("--force with no step failures must exit 0, got: %v", err)
+	}
+	if !strings.Contains(stdout, "Uninstalled") {
+		t.Errorf("expected success line on clean --force run, got stdout: %s", stdout)
+	}
+	if _, readErr := worker.Read("alpha"); !errors.Is(readErr, os.ErrNotExist) {
+		t.Errorf("local config should be deleted on clean --force run, got err=%v", readErr)
 	}
 }
 

--- a/cmd/worker_uninstall_test.go
+++ b/cmd/worker_uninstall_test.go
@@ -319,7 +319,7 @@ func TestWorkerUninstallDeleteOnServer404OnDelete(t *testing.T) {
 // TestWorkerUninstallForceContinuesPastUnbootstrapFailure: with --force,
 // an Unbootstrap error must NOT abort the command — local cleanup still
 // runs and the warning lands on stderr. But because a step failed, the
-// command must exit NON-ZERO (ErrForceStepErrors) so scripts checking $?
+// command must exit NON-ZERO (errForceStepErrors) so scripts checking $?
 // don't get a false positive on a partial failure. See justtunnel-cli#66.
 func TestWorkerUninstallForceContinuesPastUnbootstrapFailure(t *testing.T) {
 	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -344,8 +344,8 @@ func TestWorkerUninstallForceContinuesPastUnbootstrapFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("--force with a step failure must exit non-zero")
 	}
-	if !errors.Is(err, ErrForceStepErrors) {
-		t.Errorf("--force step failure should return ErrForceStepErrors, got: %v", err)
+	if !errors.Is(err, errForceStepErrors) {
+		t.Errorf("--force step failure should return errForceStepErrors, got: %v", err)
 	}
 	if _, readErr := worker.Read("alpha"); !errors.Is(readErr, os.ErrNotExist) {
 		t.Errorf("local cleanup should still run under --force, got err=%v", readErr)
@@ -360,12 +360,14 @@ func TestWorkerUninstallForceContinuesPastUnbootstrapFailure(t *testing.T) {
 	if strings.Contains(stdout, "launchctl wedged") || strings.Contains(stdout, "service teardown") {
 		t.Errorf("error summary must NOT leak onto stdout, got stdout: %s", stdout)
 	}
-	// The success line belongs on stdout only.
-	if !strings.Contains(stdout, "Uninstalled") {
-		t.Errorf("success line should appear on stdout, got stdout: %s", stdout)
+	// Partial-failure outcome line belongs on stdout. It must NOT claim a
+	// clean "Uninstalled" — that would contradict the non-zero exit and
+	// the stderr error summary.
+	if !strings.Contains(stdout, "cleanup completed with errors") {
+		t.Errorf("partial-failure outcome line should appear on stdout, got stdout: %s", stdout)
 	}
-	if strings.Contains(stderr, "Uninstalled") {
-		t.Errorf("success line must NOT leak onto stderr, got stderr: %s", stderr)
+	if strings.Contains(stdout, "Uninstalled") {
+		t.Errorf("partial-failure run must NOT print a clean 'Uninstalled' line, got stdout: %s", stdout)
 	}
 }
 
@@ -511,7 +513,7 @@ func TestWorkerUninstallProbeWarnsWhenStillRunning(t *testing.T) {
 // (service teardown + local config delete) continues. The local pointer
 // is cleaned up; the operator can still re-attempt the server delete
 // later from a permitted account. The command still exits non-zero
-// (ErrForceStepErrors) because the server step failed. See justtunnel-cli#66.
+// (errForceStepErrors) because the server step failed. See justtunnel-cli#66.
 func TestWorkerUninstallForceWith403ContinuesLocalCleanup(t *testing.T) {
 	var deleteCalls int32
 	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -549,8 +551,8 @@ func TestWorkerUninstallForceWith403ContinuesLocalCleanup(t *testing.T) {
 	if err == nil {
 		t.Fatal("--force with a server-side failure must still exit non-zero")
 	}
-	if !errors.Is(err, ErrForceStepErrors) {
-		t.Errorf("--force server failure should return ErrForceStepErrors, got: %v", err)
+	if !errors.Is(err, errForceStepErrors) {
+		t.Errorf("--force server failure should return errForceStepErrors, got: %v", err)
 	}
 	// Server-side DELETE must have been attempted FIRST.
 	if got := atomic.LoadInt32(&deleteCalls); got != 1 {
@@ -565,8 +567,10 @@ func TestWorkerUninstallForceWith403ContinuesLocalCleanup(t *testing.T) {
 		!strings.Contains(stderr, "403") {
 		t.Errorf("expected 403 / permission error in stderr, got: %s", stderr)
 	}
-	if !strings.Contains(stdout, "Uninstalled worker") {
-		t.Errorf("expected uninstall success line in stdout, got: %s", stdout)
+	// Partial failure (server 403) → stdout reports cleanup-with-errors,
+	// not a clean "Uninstalled" line.
+	if !strings.Contains(stdout, "cleanup completed with errors") {
+		t.Errorf("expected partial-failure outcome line in stdout, got: %s", stdout)
 	}
 }
 
@@ -602,6 +606,113 @@ func TestWorkerUninstallForceNoErrorsExitsZero(t *testing.T) {
 	}
 	if _, readErr := worker.Read("alpha"); !errors.Is(readErr, os.ErrNotExist) {
 		t.Errorf("local config should be deleted on clean --force run, got err=%v", readErr)
+	}
+}
+
+// TestWorkerUninstallForceTwoStepErrorsCounted exercises the multi-error
+// summary path: --force --delete-on-server where BOTH the server-side
+// DELETE fails (403) AND service teardown fails. The stderr summary must
+// report "2 step error(s)" and label both failing steps, and the command
+// must exit non-zero. This locks the count + per-error iteration that the
+// single-error tests never exercise. See justtunnel-cli#66.
+func TestWorkerUninstallForceTwoStepErrorsCounted(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.Method {
+		case http.MethodGet:
+			writer.Header().Set("Content-Type", "application/json")
+			writer.Write([]byte(`{"workers":[{"id":"wkr_1","name":"alpha","team_id":"team-acme","subdomain":"alpha--acme"}]}`))
+		case http.MethodDelete:
+			writer.WriteHeader(http.StatusForbidden)
+			writer.Write([]byte(`{"error":"only admins can delete workers"}`))
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer stub.Close()
+
+	resetWorkerState(t, uninstallTeamCfg(stub.URL))
+
+	if err := worker.Write(&worker.Config{
+		WorkerID: "wkr_1", Name: "alpha", Context: "team:team-acme",
+		Subdomain: "alpha--acme", CreatedAt: time.Now().UTC(), ServiceBackend: "launchd",
+	}); err != nil {
+		t.Fatalf("seed local: %v", err)
+	}
+
+	fake := &fakeServiceInstaller{unbootstrapErr: errors.New("launchctl wedged")}
+	withFakeInstaller(t, fake)
+	useFakeSupervisor(t, newFakeSupervisor())
+
+	stdout, stderr, err := runCmdSplit(t, "worker", "uninstall", "alpha",
+		"--delete-on-server", "--force")
+	if err == nil {
+		t.Fatal("--force with two step failures must exit non-zero")
+	}
+	if !errors.Is(err, errForceStepErrors) {
+		t.Errorf("expected errForceStepErrors, got: %v", err)
+	}
+	if !strings.Contains(stderr, "2 step error(s)") {
+		t.Errorf("summary should report 2 step errors, got stderr: %s", stderr)
+	}
+	if !strings.Contains(stderr, "server-side delete") {
+		t.Errorf("summary should label the server-side delete failure, got stderr: %s", stderr)
+	}
+	if !strings.Contains(stderr, "service teardown") {
+		t.Errorf("summary should label the service teardown failure, got stderr: %s", stderr)
+	}
+	// Local config is still cleaned up (best-effort) so stdout reports
+	// partial cleanup, never a clean "Uninstalled" line.
+	if !strings.Contains(stdout, "cleanup completed with errors") {
+		t.Errorf("expected partial-failure outcome line, got stdout: %s", stdout)
+	}
+}
+
+// TestWorkerUninstallForceAllStepsFailNoLocalState covers the three-way
+// state the skeptic flagged: --force --delete-on-server where the server
+// DELETE fails (403) AND the local config is already absent. Nothing
+// mutates (changed stays false), but the command must NOT print "already
+// uninstalled" — that would contradict the stderr error summary and the
+// non-zero exit. See justtunnel-cli#66.
+func TestWorkerUninstallForceAllStepsFailNoLocalState(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.Method {
+		case http.MethodGet:
+			writer.Header().Set("Content-Type", "application/json")
+			writer.Write([]byte(`{"workers":[{"id":"wkr_1","name":"alpha","team_id":"team-acme","subdomain":"alpha--acme"}]}`))
+		case http.MethodDelete:
+			writer.WriteHeader(http.StatusForbidden)
+			writer.Write([]byte(`{"error":"only admins can delete workers"}`))
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer stub.Close()
+
+	// No local config seeded — removeLocalConfig returns changed=false.
+	resetWorkerState(t, uninstallTeamCfg(stub.URL))
+
+	fake := &fakeServiceInstaller{}
+	withFakeInstaller(t, fake)
+	useFakeSupervisor(t, newFakeSupervisor())
+
+	stdout, stderr, err := runCmdSplit(t, "worker", "uninstall", "alpha",
+		"--delete-on-server", "--force")
+	if err == nil {
+		t.Fatal("--force with a failed server step must exit non-zero")
+	}
+	if !errors.Is(err, errForceStepErrors) {
+		t.Errorf("expected errForceStepErrors, got: %v", err)
+	}
+	// The contradiction the skeptic flagged: must NOT claim "already
+	// uninstalled" while the exit is non-zero and stderr shows an error.
+	if strings.Contains(stdout, "already uninstalled") {
+		t.Errorf("must NOT print 'already uninstalled' on a failed --force run, got stdout: %s", stdout)
+	}
+	if !strings.Contains(stdout, "cleanup completed with errors") {
+		t.Errorf("expected partial-failure outcome line, got stdout: %s", stdout)
+	}
+	if !strings.Contains(stderr, "server-side delete") {
+		t.Errorf("expected server-side delete failure in summary, got stderr: %s", stderr)
 	}
 }
 


### PR DESCRIPTION
**Problem.** With --force, collected step errors are printed to stderr but the function returns nil (exit 0). Scripts checking $? get a false positive on partial failure (e.g. server-side delete 403 + local service still registered). Intentional best-effort, but the exit-code contract is undocumented.

**Fix.** Return a sentinel non-zero error when --force collected any step errors (or add a --strict flag), and document the exit-code semantics in the command help.

**Where.** justtunnel-cli/cmd/worker_uninstall.go:202

Closes #66
