### PR TITLE
watcher.go Remove/Rename branch is dead code — watcher goes silent after rename-replace

### DIFF
--- a/internal/tui/watcher.go
+++ b/internal/tui/watcher.go
@@ -15,6 +15,29 @@ const (
 	debounceDelay = 100 * time.Millisecond
 )
 
+// isRelevantEvent reports whether an fsnotify event should trigger a debounced
+// reload. We care about writes, creates (editors that write a new file then
+// rename), removes (config deleted), and renames (atomic save).
+func isRelevantEvent(event fsnotify.Event) bool {
+	return event.Has(fsnotify.Write) ||
+		event.Has(fsnotify.Create) ||
+		event.Has(fsnotify.Remove) ||
+		event.Has(fsnotify.Rename)
+}
+
+// accumulateRewatch carries the "watch was dropped" state across a debounce
+// window. A Remove/Rename drops the underlying fsnotify watch and must trigger
+// a re-watch; a trailing Write/Create within the same window must NOT clear that
+// need. It is therefore sticky: once true it stays true for the window, which is
+// reset by the caller when a new window opens. Kept pure so the order-independent
+// behavior can be tested without timing.
+func accumulateRewatch(pending bool, event fsnotify.Event) bool {
+	if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
+		return true
+	}
+	return pending
+}
+
 // ConfigWatcher watches a config file for changes using fsnotify and sends
 // ConfigChangedMsg or ConfigReloadErrorMsg to the TUI via a MessageSender.
 type ConfigWatcher struct {
@@ -69,6 +92,17 @@ func (w *ConfigWatcher) Stop() {
 func (w *ConfigWatcher) watchLoop() {
 	var debounceTimer *time.Timer
 
+	// pendingRewatch accumulates across the debounce window. A remove/rename
+	// drops the underlying watch, and editor atomic saves commonly emit a
+	// Rename/Remove followed by a trailing Create/Write within the window.
+	// The debounce timer only ever fires the last event's closure, so we must
+	// remember that a rewatch is needed regardless of which event arrives last;
+	// otherwise the trailing event would reset it to false and the re-watch is
+	// skipped, silently dropping the watch on the next save. The flag lives only
+	// in this goroutine; it is cleared when a new window opens after the previous
+	// debounce already fired (see the Stop()==false check below).
+	pendingRewatch := false
+
 	for {
 		select {
 		case <-w.stopCh:
@@ -84,17 +118,23 @@ func (w *ConfigWatcher) watchLoop() {
 
 			// We care about writes, creates (some editors write to a new file then rename),
 			// and removes (config deleted).
-			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
-				// Reset the debounce timer on each event
-				if debounceTimer != nil {
-					debounceTimer.Stop()
+			if isRelevantEvent(event) {
+				// Reset the debounce timer on each event. Timer.Stop reports false
+				// when the previous timer already fired, which means the previous
+				// debounce window completed (its reload ran) — so this event opens
+				// a fresh window and the accumulated rewatch flag must be cleared.
+				if debounceTimer == nil || !debounceTimer.Stop() {
+					pendingRewatch = false
 				}
 
 				// fsnotify drops the watch when the file is removed or renamed
 				// (e.g. an editor's atomic save: write tmp, rename over original).
 				// In that case we must re-add the watch after reloading, otherwise
-				// the watcher fires once and then goes permanently silent.
-				rewatch := event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename)
+				// the watcher fires once and then goes permanently silent. The flag
+				// is sticky across the whole debounce window so a trailing Write/Create
+				// after the rename does not flip it back to false.
+				pendingRewatch = accumulateRewatch(pendingRewatch, event)
+				rewatch := pendingRewatch
 				debounceTimer = time.AfterFunc(debounceDelay, func() {
 					w.handleReload(rewatch)
 				})
@@ -133,11 +173,20 @@ func (w *ConfigWatcher) handleReload(rewatch bool) {
 
 	// The reload succeeded, so the path exists again. Re-add the watch that
 	// fsnotify dropped on the remove/rename, ignoring "already watching" no-ops.
+	// rewatchErr is reported after the config change below so the valid diff is
+	// still applied — the reload genuinely succeeded; only live-reload degraded.
+	var rewatchErr error
 	if rewatch {
-		if err := w.watcher.Add(w.configPath); err != nil {
-			w.sender.Send(ConfigReloadErrorMsg{
-				Error: fmt.Sprintf("re-watch config file %q: %v", w.configPath, err),
-			})
+		// Re-check stop: Stop() closes the watcher, and calling Add on a closed
+		// watcher races with that close. The second check shrinks the window
+		// between the AfterFunc firing and a concurrent Stop().
+		select {
+		case <-w.stopCh:
+			return
+		default:
+		}
+		if addErr := w.watcher.Add(w.configPath); addErr != nil {
+			rewatchErr = addErr
 		}
 	}
 
@@ -149,6 +198,16 @@ func (w *ConfigWatcher) handleReload(rewatch bool) {
 		w.sender.Send(ConfigChangedMsg{
 			ToAdd:    diff.ToAdd,
 			ToRemove: diff.ToRemove,
+		})
+	}
+
+	// Re-watching failed after a successful reload: the change above was applied,
+	// but fsnotify is no longer watching the file, so live-reload is now dead until
+	// the watcher restarts. Report this distinctly so it does not read as a reload
+	// failure (the config loaded fine) — it is a degraded-watch warning.
+	if rewatchErr != nil {
+		w.sender.Send(ConfigReloadErrorMsg{
+			Error: fmt.Sprintf("config applied, but live-reload stopped (could not re-watch %q): %v", w.configPath, rewatchErr),
 		})
 	}
 }

--- a/internal/tui/watcher.go
+++ b/internal/tui/watcher.go
@@ -90,17 +90,14 @@ func (w *ConfigWatcher) watchLoop() {
 					debounceTimer.Stop()
 				}
 
-				if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
-					// File was removed or renamed. Send error and try to re-watch.
-					// Use a short debounce since editors may recreate the file.
-					debounceTimer = time.AfterFunc(debounceDelay, func() {
-						w.handleReload()
-					})
-				} else {
-					debounceTimer = time.AfterFunc(debounceDelay, func() {
-						w.handleReload()
-					})
-				}
+				// fsnotify drops the watch when the file is removed or renamed
+				// (e.g. an editor's atomic save: write tmp, rename over original).
+				// In that case we must re-add the watch after reloading, otherwise
+				// the watcher fires once and then goes permanently silent.
+				rewatch := event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename)
+				debounceTimer = time.AfterFunc(debounceDelay, func() {
+					w.handleReload(rewatch)
+				})
 			}
 
 		case watchErr, ok := <-w.watcher.Errors:
@@ -115,7 +112,10 @@ func (w *ConfigWatcher) watchLoop() {
 }
 
 // handleReload loads the config file, computes a diff, and sends the appropriate message.
-func (w *ConfigWatcher) handleReload() {
+// When rewatch is true the triggering event removed or renamed the file, which causes
+// fsnotify to drop the watch; after a successful reload we re-add it so subsequent
+// changes (such as repeated editor atomic saves) keep being picked up.
+func (w *ConfigWatcher) handleReload(rewatch bool) {
 	// Check if stopped before sending
 	select {
 	case <-w.stopCh:
@@ -129,6 +129,16 @@ func (w *ConfigWatcher) handleReload() {
 			Error: fmt.Sprintf("config reload failed: %v", err),
 		})
 		return
+	}
+
+	// The reload succeeded, so the path exists again. Re-add the watch that
+	// fsnotify dropped on the remove/rename, ignoring "already watching" no-ops.
+	if rewatch {
+		if err := w.watcher.Add(w.configPath); err != nil {
+			w.sender.Send(ConfigReloadErrorMsg{
+				Error: fmt.Sprintf("re-watch config file %q: %v", w.configPath, err),
+			})
+		}
 	}
 
 	currentTunnels := w.manager.Tunnels()

--- a/internal/tui/watcher_test.go
+++ b/internal/tui/watcher_test.go
@@ -3,11 +3,13 @@ package tui
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/fsnotify/fsnotify"
 )
 
 // watcherMsgCollector collects tea.Msg values sent by the ConfigWatcher.
@@ -67,6 +69,22 @@ func writeWatcherConfig(t *testing.T, configPath string, content string) {
 	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
 		t.Fatalf("failed to write config: %v", err)
 	}
+}
+
+// waitForWatched polls the watcher's WatchList until configPath appears or the
+// timeout elapses. Used to settle the re-watch before driving the next event so
+// tests do not race the watch re-registration.
+func waitForWatched(watcher *ConfigWatcher, configPath string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, watched := range watcher.watcher.WatchList() {
+			if watched == configPath {
+				return true
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
 }
 
 func TestConfigWatcher_FileChangeProducesMessage(t *testing.T) {
@@ -333,6 +351,156 @@ func TestConfigWatcher_ReWatchesAfterRenameReplace(t *testing.T) {
 	}
 }
 
+// TestAccumulateRewatch_StickyAcrossWindow locks in the order-independent
+// sticky-flag behavior deterministically (no timing, no fsnotify backend
+// dependency). The bug it guards against: an editor atomic save emits a
+// Rename/Remove followed by a trailing Create/Write within the debounce window;
+// only the last event's value reaches handleReload, so if the flag were
+// recomputed per-event the trailing Write would reset rewatch to false and the
+// dropped watch would never be re-added — the watcher goes silent on the next save.
+func TestAccumulateRewatch_StickyAcrossWindow(t *testing.T) {
+	t.Parallel()
+
+	const configPath = "tunnels.yaml"
+	renameEvent := fsnotify.Event{Name: configPath, Op: fsnotify.Rename}
+	removeEvent := fsnotify.Event{Name: configPath, Op: fsnotify.Remove}
+	writeEvent := fsnotify.Event{Name: configPath, Op: fsnotify.Write}
+	createEvent := fsnotify.Event{Name: configPath, Op: fsnotify.Create}
+
+	tests := []struct {
+		name     string
+		sequence []fsnotify.Event
+		want     bool
+	}{
+		{
+			name:     "rename then trailing write stays sticky",
+			sequence: []fsnotify.Event{renameEvent, writeEvent},
+			want:     true,
+		},
+		{
+			name:     "remove then create then write stays sticky",
+			sequence: []fsnotify.Event{removeEvent, createEvent, writeEvent},
+			want:     true,
+		},
+		{
+			name:     "write then rename is true",
+			sequence: []fsnotify.Event{writeEvent, renameEvent},
+			want:     true,
+		},
+		{
+			name:     "only writes never request rewatch",
+			sequence: []fsnotify.Event{writeEvent, writeEvent},
+			want:     false,
+		},
+		{
+			name:     "single rename requests rewatch",
+			sequence: []fsnotify.Event{renameEvent},
+			want:     true,
+		},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			// Simulate one debounce window: the flag starts fresh and accumulates
+			// across every event in the burst, mirroring watchLoop.
+			pendingRewatch := false
+			for _, event := range testCase.sequence {
+				pendingRewatch = accumulateRewatch(pendingRewatch, event)
+			}
+			if pendingRewatch != testCase.want {
+				t.Errorf("after %v: accumulated rewatch = %v, want %v", testCase.sequence, pendingRewatch, testCase.want)
+			}
+		})
+	}
+}
+
+// TestConfigWatcher_RewatchFailureStillAppliesDiff documents the deliberate
+// double-send when re-watching fails after a successful reload: the config
+// loaded fine, so the diff is applied (ConfigChangedMsg), and a *distinct*
+// degraded-watch notice is sent so the user knows live-reload stopped. The
+// notice must NOT read as a reload failure (the reload succeeded).
+func TestConfigWatcher_RewatchFailureStillAppliesDiff(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "tunnels.yaml")
+
+	initialYAML := "tunnels:\n  - port: 3000\n    name: frontend\n"
+	writeWatcherConfig(t, configPath, initialYAML)
+
+	collector := newWatcherMsgCollector()
+	mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
+	watcher, err := NewConfigWatcher(configPath, mgr, collector)
+	if err != nil {
+		t.Fatalf("NewConfigWatcher failed: %v", err)
+	}
+
+	// Add a tunnel to the config so the reload produces a non-empty diff.
+	writeWatcherConfig(t, configPath, "tunnels:\n  - port: 3000\n    name: frontend\n  - port: 8080\n    name: api\n")
+
+	// Close only the underlying fsnotify watcher (not stopCh) so the re-watch
+	// Add() fails while the reload itself still succeeds. stopCh stays open so
+	// handleReload proceeds past its stop checks.
+	if closeErr := watcher.watcher.Close(); closeErr != nil {
+		t.Fatalf("failed to close underlying watcher: %v", closeErr)
+	}
+
+	watcher.handleReload(true)
+
+	var sawChange, sawDegraded bool
+	for _, msg := range collector.Messages() {
+		switch typed := msg.(type) {
+		case ConfigChangedMsg:
+			sawChange = true
+		case ConfigReloadErrorMsg:
+			sawDegraded = true
+			if strings.Contains(typed.Error, "config reload failed") {
+				t.Errorf("re-watch failure must not masquerade as a reload failure; got %q", typed.Error)
+			}
+			if !strings.Contains(typed.Error, "live-reload stopped") {
+				t.Errorf("expected a distinct degraded-watch notice, got %q", typed.Error)
+			}
+		}
+	}
+
+	if !sawChange {
+		t.Error("expected ConfigChangedMsg: the reload succeeded so the valid diff must still be applied")
+	}
+	if !sawDegraded {
+		t.Error("expected a degraded-watch ConfigReloadErrorMsg when re-watch fails")
+	}
+}
+
+// TestIsRelevantEvent verifies which fsnotify ops trigger a reload.
+func TestIsRelevantEvent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		op   fsnotify.Op
+		want bool
+	}{
+		{name: "write", op: fsnotify.Write, want: true},
+		{name: "create", op: fsnotify.Create, want: true},
+		{name: "remove", op: fsnotify.Remove, want: true},
+		{name: "rename", op: fsnotify.Rename, want: true},
+		{name: "chmod ignored", op: fsnotify.Chmod, want: false},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			event := fsnotify.Event{Name: "tunnels.yaml", Op: testCase.op}
+			if got := isRelevantEvent(event); got != testCase.want {
+				t.Errorf("isRelevantEvent(%v) = %v, want %v", testCase.op, got, testCase.want)
+			}
+		})
+	}
+}
+
 // TestConfigWatcher_KeepsWatchingAfterRenameReplace is an end-to-end check that
 // repeated editor atomic saves (write tmp + rename) keep producing change
 // messages instead of the watcher going silent after the first rename.
@@ -368,6 +536,16 @@ func TestConfigWatcher_KeepsWatchingAfterRenameReplace(t *testing.T) {
 		t.Fatal("expected ConfigChangedMsg after first rename-replace, got none")
 	}
 
+	// Wait for the watch to be re-established before firing the second write.
+	// handleReload re-adds the watch after the rename drops it; the first
+	// ConfigChangedMsg can arrive a hair before WatchList reflects the re-add.
+	// Without settling, the second atomic write can land before the watch is
+	// back, dropping the event and flaking the test (it would then look like the
+	// re-watch fix failed when it is really a timing artifact).
+	if !waitForWatched(watcher, configPath, time.Second) {
+		t.Fatalf("watch on %q was not re-established after first rename-replace", configPath)
+	}
+
 	collector.Reset()
 
 	// Second atomic save adds port 9090. Before the fix the watcher was silent
@@ -380,8 +558,8 @@ func TestConfigWatcher_KeepsWatchingAfterRenameReplace(t *testing.T) {
 		if !ok {
 			return false
 		}
-		for _, preset := range changed.ToAdd {
-			if preset.Port == 9090 {
+		for _, tunnel := range changed.ToAdd {
+			if tunnel.Port == 9090 {
 				return true
 			}
 		}

--- a/internal/tui/watcher_test.go
+++ b/internal/tui/watcher_test.go
@@ -271,6 +271,127 @@ func TestConfigWatcher_DeletedConfigSendsError(t *testing.T) {
 	}
 }
 
+// writeWatcherConfigAtomic mimics how editors save: write to a temp file in the
+// same directory, then rename it over the target. This triggers an fsnotify
+// Remove/Rename event on the watched path and drops the underlying watch.
+func writeWatcherConfigAtomic(t *testing.T, configPath string, content string) {
+	t.Helper()
+	tmpPath := configPath + ".tmp"
+	if err := os.WriteFile(tmpPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write temp config: %v", err)
+	}
+	if err := os.Rename(tmpPath, configPath); err != nil {
+		t.Fatalf("failed to rename temp config: %v", err)
+	}
+}
+
+// TestConfigWatcher_ReWatchesAfterRenameReplace proves the fix deterministically
+// across platforms: after a remove/rename drops the underlying fsnotify watch,
+// a successful reload re-adds the watch so later changes keep being delivered.
+// inotify (Linux) drops the watch on rename-replace; we simulate that dropped
+// state directly so the assertion holds regardless of the host's fsnotify backend.
+func TestConfigWatcher_ReWatchesAfterRenameReplace(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "tunnels.yaml")
+
+	initialYAML := "tunnels:\n  - port: 3000\n    name: frontend\n"
+	writeWatcherConfig(t, configPath, initialYAML)
+
+	collector := newWatcherMsgCollector()
+	mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
+	watcher, err := NewConfigWatcher(configPath, mgr, collector)
+	if err != nil {
+		t.Fatalf("NewConfigWatcher failed: %v", err)
+	}
+	defer watcher.Stop()
+
+	// Simulate the inotify behavior on rename-replace: the watch is gone.
+	if err := watcher.watcher.Remove(configPath); err != nil {
+		t.Fatalf("failed to drop watch to simulate rename: %v", err)
+	}
+	for _, watched := range watcher.watcher.WatchList() {
+		if watched == configPath {
+			t.Fatalf("precondition failed: %q still watched after Remove", configPath)
+		}
+	}
+
+	// A remove/rename-triggered reload must re-add the watch.
+	writeWatcherConfig(t, configPath, "tunnels:\n  - port: 3000\n    name: frontend\n  - port: 8080\n    name: api\n")
+	watcher.handleReload(true)
+
+	rewatched := false
+	for _, watched := range watcher.watcher.WatchList() {
+		if watched == configPath {
+			rewatched = true
+			break
+		}
+	}
+	if !rewatched {
+		t.Fatalf("expected %q to be re-watched after rename-replace reload; watcher would go silent", configPath)
+	}
+}
+
+// TestConfigWatcher_KeepsWatchingAfterRenameReplace is an end-to-end check that
+// repeated editor atomic saves (write tmp + rename) keep producing change
+// messages instead of the watcher going silent after the first rename.
+func TestConfigWatcher_KeepsWatchingAfterRenameReplace(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "tunnels.yaml")
+
+	initialYAML := "tunnels:\n  - port: 3000\n    name: frontend\n"
+	writeWatcherConfig(t, configPath, initialYAML)
+
+	collector := newWatcherMsgCollector()
+	mgr := NewTunnelManager(mockTunnelFactory(nil), collector)
+	watcher, err := NewConfigWatcher(configPath, mgr, collector)
+	if err != nil {
+		t.Fatalf("NewConfigWatcher failed: %v", err)
+	}
+	defer watcher.Stop()
+
+	watcher.Start()
+
+	// First atomic save (rename-replace) adds port 8080. fsnotify drops the
+	// watch on the rename; handleReload must re-add it.
+	firstYAML := "tunnels:\n  - port: 3000\n    name: frontend\n  - port: 8080\n    name: api\n"
+	writeWatcherConfigAtomic(t, configPath, firstYAML)
+
+	foundFirst := collector.waitForMessage(500*time.Millisecond, func(msg tea.Msg) bool {
+		changed, ok := msg.(ConfigChangedMsg)
+		return ok && len(changed.ToAdd) > 0
+	})
+	if !foundFirst {
+		t.Fatal("expected ConfigChangedMsg after first rename-replace, got none")
+	}
+
+	collector.Reset()
+
+	// Second atomic save adds port 9090. Before the fix the watcher was silent
+	// after the first rename, so this change would never be picked up.
+	secondYAML := "tunnels:\n  - port: 3000\n    name: frontend\n  - port: 8080\n    name: api\n  - port: 9090\n    name: admin\n"
+	writeWatcherConfigAtomic(t, configPath, secondYAML)
+
+	foundSecond := collector.waitForMessage(1*time.Second, func(msg tea.Msg) bool {
+		changed, ok := msg.(ConfigChangedMsg)
+		if !ok {
+			return false
+		}
+		for _, preset := range changed.ToAdd {
+			if preset.Port == 9090 {
+				return true
+			}
+		}
+		return false
+	})
+	if !foundSecond {
+		t.Fatal("expected ConfigChangedMsg for port 9090 after second rename-replace; watcher went silent after the first rename")
+	}
+}
+
 func TestModelHandlesConfigChangedMsg(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Problem.** Both arms of the Remove/Rename branch call handleReload identically; the advertised 'send error and re-watch' is not implemented. fsnotify drops the watch when the file is deleted, so after an editor atomic rename-replace (write tmp + rename) the watcher fires once then goes permanently silent — config changes stop being picked up.

**Fix.** Collapse the two arms, and implement the re-watch by calling w.watcher.Add(w.configPath) inside handleReload after a successful reload following a Remove/Rename.

**Where.** justtunnel-cli/internal/tui/watcher.go:93

Closes #63
