### PR TITLE
No-arg invocation exits 0 instead of non-zero

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -116,9 +116,12 @@ func runTunnel(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Need at least a port arg or a config file
-	if port == 0 && tunnelConfigFile == "" {
-		return cmd.Help()
+	// Need at least a port arg or a config file. Return a typed error so
+	// Execute propagates a non-nil error and os.Exit(1) fires — cmd.Help()
+	// always returns nil, which made `justtunnel || fallback` and
+	// `if justtunnel; then` shell/CI idioms see a success exit code.
+	if guardErr := guardMissingTarget(port, tunnelConfigFile); guardErr != nil {
+		return guardErr
 	}
 
 	cfg, err := config.Load(cfgFile)
@@ -373,6 +376,17 @@ func guardNonTTYPort(port int) error {
 // (port==0) has nothing to dial in single-tunnel mode and must use the TUI.
 func guardTUIFallback(port int) error {
 	return requireSingleTunnelPort(port, "port argument is required to fall back to single-tunnel mode; multi-tunnel config files need the interactive TUI")
+}
+
+// guardMissingTarget rejects an invocation with neither a port arg nor a
+// --config-file. Returning a typed InputError (instead of cmd.Help(), which
+// returns nil) makes Execute propagate a non-nil error so os.Exit(1) fires,
+// keeping `justtunnel || fallback` and `if justtunnel; then` idioms correct.
+func guardMissingTarget(port int, configFile string) error {
+	if port == 0 && configFile == "" {
+		return display.InputError("provide a port (e.g. `justtunnel 3000`) or a --config-file; run `justtunnel --help` for usage")
+	}
+	return nil
 }
 
 // runNonTTY is the original single-tunnel flow for non-terminal output (pipes, etc.).

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -111,3 +111,34 @@ func TestGuardNonTTYPort_AllowsNonZeroPort(t *testing.T) {
 		t.Fatalf("expected no error for non-zero port, got %v", err)
 	}
 }
+
+// guardMissingTarget backs the no-arg entry point. With neither a port nor a
+// --config-file it must return a non-nil typed error so Execute exits non-zero,
+// instead of cmd.Help() which always returns nil and exits 0 — breaking
+// `justtunnel || fallback` and `if justtunnel; then` shell/CI idioms.
+func TestGuardMissingTarget_RejectsNoPortNoConfig(t *testing.T) {
+	err := guardMissingTarget(0, "")
+	if err == nil {
+		t.Fatal("expected an error with no port and no config file, got nil")
+	}
+
+	var cliErr *display.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *display.CLIError, got %T", err)
+	}
+	if cliErr.Category != display.CategoryInput {
+		t.Errorf("expected CategoryInput, got %v", cliErr.Category)
+	}
+}
+
+func TestGuardMissingTarget_AllowsPort(t *testing.T) {
+	if err := guardMissingTarget(8080, ""); err != nil {
+		t.Fatalf("expected no error when a port is supplied, got %v", err)
+	}
+}
+
+func TestGuardMissingTarget_AllowsConfigFile(t *testing.T) {
+	if err := guardMissingTarget(0, "tunnels.yaml"); err != nil {
+		t.Fatalf("expected no error when a config file is supplied, got %v", err)
+	}
+}


### PR DESCRIPTION
Stacked on `fix/cli-1-tui-fallback-dials-localhost-0-when` — review/merge the base first.

**Problem.** With no port and no config file, the command returns cmd.Help() which always returns nil, so the binary exits 0. This breaks `justtunnel || fallback` and `if justtunnel; then` shell/CI idioms.

**Fix.** Return a typed error (display.InputError) instead of cmd.Help() so Execute propagates a non-nil error and os.Exit(1) fires.

**Where.** justtunnel-cli/cmd/root.go:121

Closes #65
