### PR TITLE
Tunnel reconnect backoff cap (30s, no jitter) diverges from worker runner (60s, jittered)

### DIFF
--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -1,0 +1,71 @@
+// Package backoff provides the shared exponential-backoff schedule used by
+// every reconnect loop in the CLI (tunnel client and worker runner). Keeping
+// one implementation guarantees both paths use the same cap and jitter so a
+// server restart does not synchronize reconnects into a thundering herd.
+package backoff
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// BaseDelay is the wait before the first reconnect attempt; subsequent
+// attempts double it until MaxDelay.
+const BaseDelay = time.Second
+
+// MaxDelay is the hard cap on the backoff wait, enforced AFTER jitter so the
+// returned duration NEVER exceeds it even when jitter rounds upward.
+const MaxDelay = 60 * time.Second
+
+// global rng + mutex back the package-level Compute convenience wrapper. Hot
+// reconnect loops should hold a per-loop *rand.Rand and call ComputeWithRand
+// to avoid this lock; Compute exists for tests and ad-hoc one-off callers.
+var (
+	globalMu  sync.Mutex
+	globalRng = rand.New(rand.NewSource(time.Now().UnixNano()))
+)
+
+// Compute returns the wait before the Nth reconnect attempt using a shared,
+// mutex-guarded rng. Prefer ComputeWithRand with a per-loop rng in production
+// reconnect loops.
+func Compute(attempt int) time.Duration {
+	globalMu.Lock()
+	defer globalMu.Unlock()
+	return ComputeWithRand(attempt, globalRng)
+}
+
+// ComputeWithRand returns the wait before the Nth reconnect attempt. The
+// schedule is BaseDelay*2^(attempt-1) clamped to MaxDelay, then spread by
+// ±25% uniform jitter to desynchronize reconnects across many clients. The
+// MaxDelay cap is applied AFTER jitter so the result is always in [0, MaxDelay].
+//
+// attempt < 1 is treated as 1 so a caller off-by-one never produces a
+// zero-length spin. rng is not used for anything security-sensitive.
+func ComputeWithRand(attempt int, rng *rand.Rand) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	// Compute 2^(attempt-1) with overflow protection: attempt-1 >= 6 already
+	// saturates the cap, so clamp the multiplier there.
+	multiplier := 1
+	if attempt-1 >= 6 {
+		multiplier = 64 // produces >= MaxDelay, clamped below
+	} else {
+		multiplier = 1 << (attempt - 1)
+	}
+	wait := BaseDelay * time.Duration(multiplier)
+	if wait > MaxDelay {
+		wait = MaxDelay
+	}
+	// Uniform jitter in [-25%, +25%].
+	jitterFraction := (rng.Float64() - 0.5) * 0.5
+	jittered := time.Duration(float64(wait) * (1.0 + jitterFraction))
+	if jittered > MaxDelay {
+		jittered = MaxDelay
+	}
+	if jittered < 0 {
+		jittered = 0
+	}
+	return jittered
+}

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -1,0 +1,66 @@
+package backoff
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+// TestComputeSchedule verifies the exponential schedule (1s base, doubling)
+// capped at 60s, with every sample staying inside the ±25% jitter band.
+func TestComputeSchedule(t *testing.T) {
+	tests := []struct {
+		attempt int
+		base    time.Duration // expected base before jitter
+	}{
+		{1, 1 * time.Second},
+		{2, 2 * time.Second},
+		{3, 4 * time.Second},
+		{4, 8 * time.Second},
+		{5, 16 * time.Second},
+		{6, 32 * time.Second},
+		{7, 60 * time.Second}, // 64s capped to 60s
+		{8, 60 * time.Second},
+		{50, 60 * time.Second}, // far past cap, no overflow
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("attempt_%d", tc.attempt), func(t *testing.T) {
+			low := time.Duration(float64(tc.base) * 0.75)
+			high := time.Duration(float64(tc.base) * 1.25)
+			for sample := 0; sample < 100; sample++ {
+				got := Compute(tc.attempt)
+				if got < low || got > high {
+					t.Fatalf("Compute(%d) = %s; want within [%s, %s]",
+						tc.attempt, got, low, high)
+				}
+			}
+		})
+	}
+}
+
+// TestComputeNonPositiveAttempt clamps attempts <= 0 to the 1s base so a
+// caller off-by-one never produces a zero-length spin.
+func TestComputeNonPositiveAttempt(t *testing.T) {
+	for _, attempt := range []int{0, -1, -100} {
+		got := Compute(attempt)
+		if got < 750*time.Millisecond || got > 1250*time.Millisecond {
+			t.Fatalf("Compute(%d) = %s; want clamped to ~1s±25%%", attempt, got)
+		}
+	}
+}
+
+// TestComputeRespectsCapAfterJitter guards that the MaxDelay cap holds even
+// when jitter rounds upward — the result is always in [0, MaxDelay].
+func TestComputeRespectsCapAfterJitter(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	for sample := 0; sample < 5000; sample++ {
+		got := ComputeWithRand(100, rng)
+		if got > MaxDelay {
+			t.Fatalf("ComputeWithRand(100) = %s; exceeds %s cap (sample %d)", got, MaxDelay, sample)
+		}
+		if got < 0 {
+			t.Fatalf("ComputeWithRand(100) = %s; negative (sample %d)", got, sample)
+		}
+	}
+}

--- a/internal/tunnel/reconnect_test.go
+++ b/internal/tunnel/reconnect_test.go
@@ -160,9 +160,10 @@ func TestReconnectGivesUpAfterMaxAttempts(t *testing.T) {
 	}
 }
 
-// TestReconnectBackoffSchedule asserts the exponential backoff sequence
-// (1s, 2s, 4s, ...) capped at 30s by recording the durations the reconnect
-// loop sleeps for before each retry dial.
+// TestReconnectBackoffSchedule asserts the reconnect loop feeds each attempt
+// number to its backoff function and sleeps for whatever that function returns.
+// A deterministic injected backoff keeps the assertion exact; jitter is covered
+// separately by TestReconnectBackoffUsesSharedSchedule.
 func TestReconnectBackoffSchedule(t *testing.T) {
 	relay := &fakeRelay{
 		dropAfterAssign: true,
@@ -174,6 +175,10 @@ func TestReconnectBackoffSchedule(t *testing.T) {
 	sleep, schedule := recordingSleep()
 	tun := New(wsURL, "http://localhost:0", "", discardLogger(), Callbacks{})
 	tun.sleep = sleep
+	// Deterministic per-attempt backoff so the recorded schedule is exact.
+	tun.backoff = func(attempt int) time.Duration {
+		return time.Duration(attempt) * time.Second
+	}
 	tun.SetMaxReconnectAttempts(8)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -184,12 +189,12 @@ func TestReconnectBackoffSchedule(t *testing.T) {
 	want := []time.Duration{
 		1 * time.Second,
 		2 * time.Second,
+		3 * time.Second,
 		4 * time.Second,
+		5 * time.Second,
+		6 * time.Second,
+		7 * time.Second,
 		8 * time.Second,
-		16 * time.Second,
-		30 * time.Second, // 32s capped to 30s
-		30 * time.Second,
-		30 * time.Second,
 	}
 	got := schedule()
 	if len(got) != len(want) {
@@ -198,6 +203,57 @@ func TestReconnectBackoffSchedule(t *testing.T) {
 	for index := range want {
 		if got[index] != want[index] {
 			t.Errorf("backoff[%d]: got %s, want %s (full schedule %v)", index, got[index], want[index], got)
+		}
+	}
+}
+
+// TestReconnectBackoffUsesSharedSchedule asserts the default backoff (no
+// injection) follows the shared backoff package: exponential base doubling,
+// capped at 60s, with every wait staying inside the ±25% jitter band. This is
+// the regression guard for CLI-9 — the tunnel must NOT use the old 30s,
+// no-jitter cap.
+func TestReconnectBackoffUsesSharedSchedule(t *testing.T) {
+	relay := &fakeRelay{
+		dropAfterAssign: true,
+		rejectFrom:      2,
+		rejectCode:      http.StatusBadGateway,
+	}
+	wsURL := newFakeRelay(t, relay)
+
+	sleep, schedule := recordingSleep()
+	tun := New(wsURL, "http://localhost:0", "", discardLogger(), Callbacks{})
+	tun.sleep = sleep // uses the default jittered backoff from New
+	tun.SetMaxReconnectAttempts(8)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_ = tun.Run(ctx)
+
+	got := schedule()
+	// Expected base before jitter per attempt: 1,2,4,8,16,32,60(capped),60.
+	wantBase := []time.Duration{
+		1 * time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		16 * time.Second,
+		32 * time.Second,
+		60 * time.Second,
+		60 * time.Second,
+	}
+	if len(got) != len(wantBase) {
+		t.Fatalf("backoff schedule length: got %d (%v), want %d", len(got), got, len(wantBase))
+	}
+	for index, base := range wantBase {
+		low := time.Duration(float64(base) * 0.75)
+		high := time.Duration(float64(base) * 1.25)
+		if got[index] < low || got[index] > high {
+			t.Errorf("backoff[%d]=%s outside jitter band [%s,%s] for base %s",
+				index, got[index], low, high, base)
+		}
+		if got[index] > 60*time.Second {
+			t.Errorf("backoff[%d]=%s exceeds 60s cap", index, got[index])
 		}
 	}
 }
@@ -293,6 +349,11 @@ func TestReconnectSucceedsAfterDrop(t *testing.T) {
 		},
 	})
 	tun.sleep = sleep
+	// Deterministic backoff so the recorded wait is exact; this test asserts
+	// the count of waits, not the jitter (covered elsewhere).
+	tun.backoff = func(attempt int) time.Duration {
+		return time.Duration(attempt) * time.Second
+	}
 	tun.SetMaxReconnectAttempts(5)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -14,6 +15,7 @@ import (
 
 	"nhooyr.io/websocket"
 
+	"github.com/justtunnel/justtunnel-cli/internal/backoff"
 	"github.com/justtunnel/justtunnel-cli/internal/display"
 )
 
@@ -67,9 +69,18 @@ type Tunnel struct {
 	// observe the backoff schedule and advance time without real waits.
 	// Defaults to realSleep.
 	sleep func(ctx context.Context, duration time.Duration) error
+
+	// backoff computes the wait before the Nth reconnect attempt. Defaults to
+	// the shared backoff package (60s cap, ±25% jitter) over a per-tunnel rng
+	// so reconnects from many clients do not synchronize after a server
+	// restart. Tests inject a deterministic schedule to assert the sequence.
+	backoff func(attempt int) time.Duration
 }
 
 func New(serverURL, localTarget, authToken string, logger *slog.Logger, callbacks Callbacks) *Tunnel {
+	// Per-tunnel rng so jitter is independent across clients in the same
+	// process and across restarts; math/rand is fine for a reconnect spreader.
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	return &Tunnel{
 		serverURL:            serverURL,
 		localTarget:          localTarget,
@@ -78,6 +89,9 @@ func New(serverURL, localTarget, authToken string, logger *slog.Logger, callback
 		callbacks:            callbacks,
 		maxReconnectAttempts: 50,
 		sleep:                realSleep,
+		backoff: func(attempt int) time.Duration {
+			return backoff.ComputeWithRand(attempt, rng)
+		},
 	}
 }
 
@@ -394,7 +408,9 @@ func (t *Tunnel) buildReconnectURL() string {
 }
 
 // reconnect attempts to re-establish the WebSocket connection with
-// exponential backoff: 1s, 2s, 4s, 8s, 16s, capped at 30s.
+// exponential backoff: 1s, 2s, 4s, ... capped at 60s with ±25% jitter (see
+// the shared backoff package). The cap and jitter match the worker runner so
+// reconnects do not synchronize into a thundering herd after a server restart.
 func (t *Tunnel) reconnect(ctx context.Context) error {
 	// Wait for in-flight requests from the old connection to finish
 	// so they don't write stale responses to the new connection. Bound the
@@ -424,9 +440,6 @@ func (t *Tunnel) reconnect(ctx context.Context) error {
 	t.setReconnecting(true)
 	previousSubdomain := t.subdomain
 
-	backoff := time.Second
-	const maxBackoff = 30 * time.Second
-
 	for attempt := 1; ; attempt++ {
 		// Check max reconnect attempts (0 = unlimited).
 		if t.maxReconnectAttempts > 0 && attempt > t.maxReconnectAttempts {
@@ -437,6 +450,8 @@ func (t *Tunnel) reconnect(ctx context.Context) error {
 				attempt-1, elapsed,
 			))
 		}
+
+		backoff := t.backoff(attempt)
 
 		if t.callbacks.OnReconnecting != nil {
 			t.callbacks.OnReconnecting(attempt, backoff)
@@ -458,10 +473,6 @@ func (t *Tunnel) reconnect(ctx context.Context) error {
 				return terminalErr
 			}
 
-			backoff *= 2
-			if backoff > maxBackoff {
-				backoff = maxBackoff
-			}
 			continue
 		}
 

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -12,11 +12,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"nhooyr.io/websocket"
 
+	"github.com/justtunnel/justtunnel-cli/internal/backoff"
 	"github.com/justtunnel/justtunnel-cli/internal/config"
 )
 
@@ -426,65 +426,19 @@ func sleepCtx(ctx context.Context, duration time.Duration) error {
 	}
 }
 
-// backoffMu guards the package-level rng used by the convenience Backoff
-// function. Production runners use a per-runner *rand.Rand (see
-// backoffWithRand) and never touch this mutex; only direct callers of
-// Backoff (tests, ad-hoc code) pay the lock cost.
-var (
-	backoffMu  sync.Mutex
-	backoffRng = rand.New(rand.NewSource(time.Now().UnixNano()))
-)
-
-// Backoff computes the wait before the Nth reconnect attempt. The schedule
-// is base*2^(attempt-1) with a hard cap at 60s, then ±25% uniform jitter
-// to spread thundering-herd reconnects across many workers.
-//
-// B5: the 60s cap is enforced AFTER jitter so the actual wait NEVER exceeds
-// 60s even when jitter rounds up.
-//
-// Convenience wrapper around backoffWithRand. Production runners pass a
-// per-runner rng (see NewRunner) to avoid the global-mutex cost; this
-// variant exists for direct test calls and external one-off uses.
+// Backoff computes the wait before the Nth reconnect attempt: base*2^(attempt-1)
+// capped at 60s with ±25% jitter. Convenience wrapper around the shared
+// backoff package; production runners pass a per-runner rng (see NewRunner)
+// via backoffWithRand to avoid the shared mutex.
 func Backoff(attempt int) time.Duration {
-	backoffMu.Lock()
-	defer backoffMu.Unlock()
-	return backoffWithRand(attempt, backoffRng)
+	return backoff.Compute(attempt)
 }
 
-// backoffWithRand is the pure (modulo rng) backoff implementation. Cap is
-// applied AFTER jitter so the returned duration is bounded by maxDelay
-// regardless of jitter direction.
+// backoffWithRand computes the backoff using a caller-owned rng so each runner
+// gets its own jitter sequence without locking. Delegates to the shared
+// backoff package so the tunnel client and worker runner stay aligned.
 func backoffWithRand(attempt int, rng *rand.Rand) time.Duration {
-	if attempt < 1 {
-		attempt = 1
-	}
-	const baseDelay = time.Second
-	const maxDelay = 60 * time.Second
-	// Compute 2^(attempt-1) with overflow protection: anything >= 6 saturates
-	// the 60s cap before jitter.
-	multiplier := 1
-	if attempt-1 >= 6 {
-		multiplier = 64 // produces >= 60s, will be clamped below
-	} else {
-		multiplier = 1 << (attempt - 1)
-	}
-	wait := baseDelay * time.Duration(multiplier)
-	if wait > maxDelay {
-		wait = maxDelay
-	}
-	// Uniform jitter in [-25%, +25%]. math/rand is fine here — this is a
-	// reconnect spreader, not a security primitive.
-	jitterFraction := (rng.Float64() - 0.5) * 0.5 // [-0.25, +0.25]
-	jittered := time.Duration(float64(wait) * (1.0 + jitterFraction))
-	// Clamp AFTER jitter so the upper bound is honored even when jitter
-	// pushes a 60s wait toward 75s.
-	if jittered > maxDelay {
-		jittered = maxDelay
-	}
-	if jittered < 0 {
-		jittered = 0
-	}
-	return jittered
+	return backoff.ComputeWithRand(attempt, rng)
 }
 
 // DeriveSubdomain returns the host-router subdomain for the given worker


### PR DESCRIPTION
Stacked on `fix/cli-10-maxbodysize-shadowed-inside-connectwithurl` — review/merge the base first.

**Problem.** The tunnel client caps backoff at 30s with no jitter (synchronized retries), while the worker runner caps at 60s with ±25% jitter. The undocumented divergence doubles per-client tunnel reconnect frequency and risks thundering-herd synchronization on server restart.

**Fix.** Align both caps (60s is more conservative) and add jitter to the tunnel path; extract a shared backoff helper.

**Where.** justtunnel-cli/internal/tunnel/tunnel.go:381; justtunnel-cli/internal/worker/runner.go:462

Closes #68
